### PR TITLE
feat: server-side slot expansion engine & $generate-slots endpoint (#22)

### DIFF
--- a/README.md
+++ b/README.md
@@ -332,7 +332,7 @@ If you're modernizing a legacy EHR or want to contribute HL7v2 mappings, backend
 - [ ] Implement google/microsoft/apple login for the scheduling portal for end users
 - [ ] Implement the ability for an admin to define custom appointment types with different durations and constraints
   - [ ] Admin UI for managing providers, appointment types, and schedules
-  - [ ] Implement yaml import/export for schedule definitions including API to update
+  - [ ] Implement yaml import/export for schedule definitions including API to update (see [Schedule YAML format](docs/scheduling-models.md#step-2-define-availability-with-the-schedule-yaml-format))
   
 - [ ] FHIR Subscription support for appointment updates
 - [ ] Add SMART-on-FHIR / OAuth support - review https://github.com/mieweb/poc-auth-architecture 

--- a/WebChartSchedulerAppointments.md
+++ b/WebChartSchedulerAppointments.md
@@ -1,0 +1,692 @@
+# Scheduler & Appointments
+
+The WebChart Scheduler manages provider availability (schedules), patient appointments, appointment types, check-in/check-out, and recurrence patterns. This document describes the data model, code architecture, API, and layout system for the scheduling module.
+
+---
+
+## Architecture Overview
+
+```mermaid
+graph TB
+    subgraph "UI Layer"
+        SchedulerLayout["Scheduler.html<br/>(MIEstache Layout)"]
+        ApptScreen["Appointment Screen.html"]
+        NewApptScreen["NewApptScreen.html"]
+        SchedulesView["Schedules.html"]
+    end
+
+    subgraph "Request Handling"
+        SchedHandler["SCHED_Handler()<br/>src/scheduler.c"]
+        ApptAPI["JSON API<br/>src/api/appointments.c"]
+        DashHandler["EC_DashBoardHandler()<br/>src/dashboard.c"]
+    end
+
+    subgraph "Logic Layer"
+        SchLogic["Schedule Logic<br/>src/schlogic.c"]
+        UsageList["USAGELIST<br/>Time Matrix Engine"]
+        Recurrence["Recurrence Engine<br/>GetNextOccurrence()"]
+        Validation["SCHED_ValidateApt()"]
+    end
+
+    subgraph "Data Layer"
+        SchedDB["src/schedulerdb.c"]
+        CheckinDB["src/checkindb.c"]
+    end
+
+    subgraph "Database"
+        AppointmentsTable["appointments"]
+        SchedulesTable["schedules"]
+        AptTypes["apt_types"]
+        JunctionTables["Junction Tables<br/>(multi_resource_apt,<br/>multi_type_apt, etc.)"]
+        Revisions["appointment_revisions"]
+    end
+
+    SchedulerLayout --> SchedHandler
+    ApptScreen --> SchedHandler
+    NewApptScreen --> SchedHandler
+    SchedulesView --> SchedHandler
+    SchedHandler --> SchLogic
+    ApptAPI --> SchedDB
+    SchLogic --> UsageList
+    SchLogic --> Recurrence
+    SchedHandler --> Validation
+    Validation --> SchedDB
+    SchedDB --> AppointmentsTable
+    SchedDB --> SchedulesTable
+    SchedDB --> AptTypes
+    SchedDB --> JunctionTables
+    SchedDB --> Revisions
+    CheckinDB --> AppointmentsTable
+    DashHandler --> SchedulerLayout
+```
+
+---
+
+## Key Concepts
+
+| Concept | Description |
+|---------|-------------|
+| **Schedule** | A provider's available time block. Defines *when* a resource can accept appointments. Can recur (weekly, daily, etc.). Stored in the `schedules` table. |
+| **Appointment** | A patient booking in a provider's schedule. Links a patient, time, resource(s), and type(s). Stored in the `appointments` table. |
+| **Resource** | A schedulable entity (provider, room, equipment). Identified by `user_id` from the `users` table. Must have the `Scheduling Resources` realm. |
+| **Appointment Type** | A category of visit (e.g., "Office Visit", "Follow-Up"). Defines default duration, color, CPT code, and encounter type. Stored in `apt_types`. |
+| **Recurrence** | Both schedules and appointments support repeating patterns (daily, weekly, monthly, yearly, nth-weekday). |
+| **Check-In** | Patient arrival workflow tied to an appointment. Creates an encounter and tracks station/location. |
+
+---
+
+## Database Schema
+
+### `appointments` — Patient bookings
+
+| Column | Type | Description |
+|--------|------|-------------|
+| `id` | int (PK, auto-increment) | Appointment ID |
+| `pat_id` | int (FK → patients) | Patient |
+| `startdate` | datetime | Start date/time |
+| `enddate` | datetime | End date/time |
+| `pat_duration` | int | Patient-visible duration (minutes), can differ from slot duration |
+| `waitlist_duedate` | datetime | Due date for waitlisted appointments |
+| `remind` | int | Reminder offset in minutes before appointment |
+| `reason` | mediumtext | Reason/chief complaint |
+| `location` | varchar | Location code (e.g., `OFFICE`) |
+| `status` | varchar | Appointment status |
+| `comment` | mediumtext | Internal/staff comment |
+| `patient_instructions` | mediumtext | Patient-facing instructions |
+| `user_id` | int (FK → users) | User who created the appointment |
+| `createdate` | datetime | Creation timestamp |
+| `canceled` | tinyint | 0 = active, 1 = canceled/no-show |
+| `cancel_code` | varchar | FK → `appointment_cancel_codes.cancel_code` |
+| `cancel_date` | datetime | When canceled |
+| `confirmed` | tinyint | 0 = unconfirmed, 1 = confirmed |
+| `confirm_user` | int (FK → users) | Who confirmed |
+| `confirm_date` | datetime | When confirmed |
+| `contact` | varchar | Contact person name |
+| `contact_number` | varchar | Contact phone number |
+| `visible_date` | datetime | Date appointment becomes visible in portal |
+| `day_overlap` | tinyint | Multi-day appointment flag |
+| `interface` | varchar | External system identifier (e.g., `hl7`, `open_pm`) |
+| `external_id` | varchar | ID in the external system |
+| `filler_status_code` | varchar | HL7 filler status code |
+| **Recurrence fields** | | See [Recurrence](#recurrence) |
+
+**Computed field** (in queries):
+- `duration` = `UNIX_TIMESTAMP(enddate) - UNIX_TIMESTAMP(startdate)` (seconds)
+
+**Defined in:** `APPOINTMENT_COLS` macro in [include/schedulerdb.h](../include/schedulerdb.h)
+
+---
+
+### `schedules` — Provider availability templates
+
+| Column | Type | Description |
+|--------|------|-------------|
+| `id` | int (PK, auto-increment) | Schedule ID |
+| `resource_id` | int (FK → users) | Schedulable resource |
+| `startdate` | datetime | Block start |
+| `enddate` | datetime | Block end |
+| `remind` | int | Reminder setting |
+| `reason` | text | Schedule description |
+| `location` | varchar | Location code |
+| `status` | varchar | Schedule status |
+| `comment` | text | Internal notes |
+| `user_id` | int (FK → users) | Created by |
+| `createdate` | datetime | When created |
+| `absorb` | tinyint | Whether overbooking is absorbed |
+| `num_overbook` | int | Maximum concurrent appointments in this block |
+| `num_total_apts` | int | Total appointments allowed |
+| `color` | varchar | CSS color for display |
+| `show_add_apt_link` | tinyint | Show "Add Appointment" link |
+| `priority` | int | Display priority |
+| `portal_time_slots` | int | Slots visible on patient portal |
+| **Recurrence fields** | | See [Recurrence](#recurrence) |
+
+**Defined in:** `SCHEDULE_COLUMNS` macro in [include/schedulerdb.h](../include/schedulerdb.h)
+
+---
+
+### `apt_types` — Appointment type catalog
+
+| Column | Type | Description |
+|--------|------|-------------|
+| `apt_type_id` | int (PK, auto-increment) | Internal ID |
+| `code` | varchar (UNIQUE) | Short code (e.g., `OV`, `FU`, `TH_VIDEO`) |
+| `active` | tinyint | Whether type is active |
+| `cpt_code` | varchar | Associated CPT billing code |
+| `description` | varchar | Display name |
+| `duration` | int | Default duration (minutes) |
+| `pat_duration` | int | Patient-visible duration (minutes) |
+| `enc_type` | varchar | Default encounter visit type |
+| `color` | varchar | Background color |
+| `titlecolor` | varchar | Title bar color |
+| `display_order` | int | Sort order |
+| `comment` | text | Notes |
+| `dict_job_type` | varchar | Linked dictation job type |
+| `enc_template_name` | varchar | Encounter template to use |
+| `portal_available` | tinyint | 0 = not on portal, 1 = available on portal, 2 = waitlist only |
+
+**Special codes:** `TH_PHONE` (Telehealth Phone), `TH_VIDEO` (Telehealth Video)
+
+**Defined in:** `APPT_TYPE_COLS` macro in [include/schedulerdb.h](../include/schedulerdb.h)
+
+---
+
+### `apt_type_templates` — Context-specific appointment configuration
+
+Overrides default appointment type settings per resource and/or location combination.
+
+| Column | Type | Description |
+|--------|------|-------------|
+| `apt_code` | varchar (FK → apt_types.code) | Appointment type code |
+| `resource_id` | int (FK → users) | Resource (0 = all) |
+| `user_id` | int (FK → users) | Created by |
+| `location_code` | varchar | Location (empty = all) |
+| `duration` | int | Override duration (minutes) |
+| `pat_duration` | int | Override patient duration |
+| `visit_type` | varchar | Override encounter visit type |
+| `enc_template_name` | varchar | Override encounter template |
+| `remind` | int | Override reminder |
+| `sch_instruct` | text | Staff/scheduling instructions |
+| `clin_instruct` | text | Clinical/provider instructions |
+| `createdate` | datetime | When created |
+
+**Defined in:** `APPT_TYPE_TEMPLATE_COLS` macro in [include/schedulerdb.h](../include/schedulerdb.h)
+
+---
+
+### `appointment_cancel_codes` — Cancellation and no-show reasons
+
+| Column | Type | Description |
+|--------|------|-------------|
+| `cancel_code` | varchar (UNIQUE) | Code identifier |
+| `cancel_reason` | varchar | Descriptive reason |
+| `no_show` | tinyint | 1 = this code represents a no-show |
+
+---
+
+### `appointment_revisions` — Audit trail
+
+Mirrors the `appointments` table structure with additional audit fields:
+
+| Column | Type | Description |
+|--------|------|-------------|
+| `ar_id` | int (PK, auto-increment) | Revision record ID |
+| `id` | int | Original appointment ID |
+| `revision_number` | int | Sequential revision number |
+| `revision_date` | datetime | When the change was recorded |
+| `resources` | text | Serialized list of resource IDs |
+| `types` | text | Serialized list of appointment type codes |
+| `referrers` | text | Serialized list of referrer IDs |
+| *(plus all appointment columns)* | | Snapshot at time of change |
+
+**Unique constraint:** (`id`, `revision_number`)
+
+---
+
+### Junction Tables (Many-to-Many)
+
+| Table | Columns | Purpose |
+|-------|---------|---------|
+| `multi_resource_apt` | `apt_id`, `res_id` | Multiple providers per appointment |
+| `multi_type_apt` | `apt_id`, `code` | Multiple visit types per appointment |
+| `multi_referrer_apt` | `apt_id`, `ref_id`, `role_id` | Referring providers per appointment |
+| `multi_type_sched` | `sched_id`, `type`, `required`, `portal_available` | Types allowed per schedule block |
+| `appointments_multiday` | `apt_id`, `span_date` | Tracks each date of a multi-day appointment |
+
+---
+
+### Entity Relationship Diagram
+
+```mermaid
+erDiagram
+    appointments ||--o{ multi_resource_apt : "has resources"
+    appointments ||--o{ multi_type_apt : "has types"
+    appointments ||--o{ multi_referrer_apt : "has referrers"
+    appointments ||--o{ appointment_revisions : "audit trail"
+    appointments ||--o{ appointments_multiday : "multi-day spans"
+    appointments }o--|| patients : "for patient"
+    appointments }o--o| appointment_cancel_codes : "cancel reason"
+
+    schedules ||--o{ multi_type_sched : "allows types"
+    schedules }o--|| users : "resource"
+
+    multi_resource_apt }o--|| users : "resource"
+    multi_type_apt }o--|| apt_types : "type"
+    multi_type_sched }o--|| apt_types : "type"
+
+    apt_types ||--o{ apt_type_templates : "overrides"
+    apt_type_templates }o--o| users : "resource-specific"
+```
+
+---
+
+## Recurrence
+
+Both `appointments` and `schedules` share recurrence fields:
+
+| Column | Type | Description |
+|--------|------|-------------|
+| `recurrence` | int | Pattern type (see `RC_TYPE` enum below) |
+| `rc_interval` | int | Frequency: every N days/weeks/months |
+| `rc_instance` | int | Nth instance for monthly patterns (1st, 2nd, 3rd, 4th, last) |
+| `rc_dow` | int | Day-of-week bitmask |
+| `rc_enddate` | datetime | When recurrence stops |
+
+### Recurrence Types (`RC_TYPE` enum)
+
+| Value | Name | Description | Example |
+|-------|------|-------------|---------|
+| 0 | `RC_NONE` | No recurrence | One-time event |
+| 1 | `RC_DAILY` | Every N days | Every 2 days |
+| 2 | `RC_WEEKLY` | Every N weeks on specific days | Every week on Mon, Wed, Fri |
+| 3 | `RC_MONTHLY` | Day N of every M months | 15th of every month |
+| 4 | `RC_MONTHLY_NTH` | Nth weekday of every M months | 2nd Tuesday of every month |
+| 5 | `RC_YEARLY` | Specific date each year | March 15 every year |
+| 6 | `RC_YEARLY_NTH` | Nth weekday of a month yearly | 3rd Monday of January |
+| 7 | `RC_DOW_MONTHLY` | Day-of-week monthly | Every Tuesday this month |
+
+### Day-of-Week Bitmask (`DOW_MASK` enum)
+
+| Value | Name | Day |
+|-------|------|-----|
+| 1  | `DOW_SUN` | Sunday |
+| 2  | `DOW_MON` | Monday |
+| 4  | `DOW_TUE` | Tuesday |
+| 8  | `DOW_WED` | Wednesday |
+| 16 | `DOW_THR` | Thursday |
+| 32 | `DOW_FRI` | Friday |
+| 64 | `DOW_SAT` | Saturday |
+
+Combine with bitwise OR: `Mon + Wed + Fri` = `2 | 8 | 32` = `42`
+
+### Recurrence Engine
+
+The schedule logic layer in [include/schlogic.h](../include/schlogic.h) provides:
+
+- `RecurrenceFillStruct()` — Parses recurrence fields from an `APT_SCH` struct
+- `GetFirstOccurence()` — Calculates the first occurrence within a date range
+- `GetNextOccurence()` — Iterates to the next occurrence
+- `WebchartGetSchedules()` — Expands recurring schedules across a date range
+- `WebChartGetAppointments()` — Retrieves appointments with callback iteration
+
+---
+
+## Appointment Lifecycle
+
+```mermaid
+stateDiagram-v2
+    [*] --> Pending: Insert
+    Pending --> Confirmed: Confirm
+    Pending --> Canceled: Cancel
+    Pending --> NoShow: No-Show
+    Confirmed --> Canceled: Cancel
+    Confirmed --> CheckedIn: Patient arrives
+    CheckedIn --> CheckedOut: Visit complete
+    CheckedIn --> Canceled: Cancel
+    Canceled --> [*]
+    NoShow --> [*]
+    CheckedOut --> [*]
+
+    state Pending {
+        direction LR
+        Waitlisted: waitlist_duedate set
+        Scheduled: Normal pending
+    }
+```
+
+### Status Fields
+
+| Field | Values | Meaning |
+|-------|--------|---------|
+| `canceled` | `0` | Active appointment |
+| `canceled` | `1` | Canceled (`SCHED_APT_CANCEL`) |
+| `canceled` | `2` | No-show (`SCHED_APT_NOSHOW`) |
+| `confirmed` | `0` | Unconfirmed |
+| `confirmed` | `1` | Confirmed |
+| `waitlist_duedate` | datetime or NULL | If set, appointment is waitlisted (`SCHED_APT_WAITLIST`) |
+
+### Validation Rules
+
+Before an appointment is saved, `SCHED_ValidateApt()` (in [include/schedulerdb.h](../include/schedulerdb.h)) checks a bitmask of rules:
+
+| Code | Value | Rule | Forceable? |
+|------|-------|------|------------|
+| `SCHED_APT_VALID_OK` | 0 | All checks pass | — |
+| `SCHED_APT_VALID_START_AFTER_END` | 1 | Start time is after end time | No |
+| `SCHED_APT_VALID_START_BEFORE_NOW` | 2 | Start time is in the past | Yes |
+| `SCHED_APT_VALID_NO_RESOURCES` | 4 | No resources assigned | No |
+| `SCHED_APT_VALID_OVERBOOKED` | 8 | Resource exceeds `num_overbook` capacity | Yes |
+| `SCHED_APT_VALID_TIME_NOT_TEMPLATED` | 16 | No schedule template covers this time | Yes |
+| `SCHED_APT_VALID_PAT_INVALID` | 32 | Patient is invalid or inactive | No |
+| `SCHED_APT_VALID_INVALID_DAYS_OUT` | 64 | Booking is beyond the allowed window | No |
+
+**Forceable** means the user can override the warning and save anyway.
+
+---
+
+## Check-In Integration
+
+The check-in system ([include/checkindb.h](../include/checkindb.h)) ties appointments to patient location tracking:
+
+| Function | Purpose |
+|----------|---------|
+| `DBInsertPatLocation()` | Records a check-in action (IN, OUT, MOVE) with station, encounter, and timestamp |
+| `PatientIsCheckedIn()` | Returns encounter ID if patient is currently checked in, 0 otherwise |
+| `DBStationOccupied()` | Checks if a station is in use |
+| `EC_PatientCheckinHREF()` | Renders the check-in link in the scheduler UI |
+
+**Flow:** Appointment → Check-In → Encounter auto-created (if `enc_type` configured on appointment type) → Station tracking → Check-Out
+
+---
+
+## API Reference
+
+### Endpoint: `POST /json/appointments`
+
+Creates or updates an appointment.
+
+**Request body** (JSON object or array):
+
+```json
+{
+  "pat_id": 456,
+  "startdate": "2026-05-15 14:00:00",
+  "enddate": "2026-05-15 14:30:00",
+  "duration": 30,
+  "pat_duration": 30,
+  "res_id": [789, 790],
+  "type": ["OV", "FU"],
+  "location": "OFFICE",
+  "reason": "Regular checkup",
+  "comment": "Internal note",
+  "patient_instructions": "Bring insurance card",
+  "contact": "Patient",
+  "contact_number": "5551234567",
+  "visible_date": "2026-04-15",
+  "waitlist_duedate": "2026-05-20",
+  "confirmed": 1,
+  "remind": 1440,
+  "ref_id": [111],
+  "recurrence": 2,
+  "rc_interval": 1,
+  "rc_dow": 42,
+  "rc_enddate": "2026-12-31",
+  "interface": "hl7",
+  "external_id": "EXT123",
+  "email_pat": 1,
+  "email_resource": 1,
+  "calculate": 1,
+  "force": 0
+}
+```
+
+| Field | Required | Description |
+|-------|----------|-------------|
+| `apt_id` | No | Include to update; omit to create |
+| `pat_id` | Yes | Patient ID |
+| `startdate` | Yes | Start datetime |
+| `enddate` | Conditional | End datetime; or supply `duration` |
+| `duration` | Conditional | Minutes; auto-calculated from types if `calculate=1` |
+| `pat_duration` | No | Patient-facing duration in minutes |
+| `res_id` | Yes | Resource ID(s) — single int or array |
+| `type` | No | Appointment type code(s) — single string or array |
+| `location` | No | Location code |
+| `reason` | No | Chief complaint / reason |
+| `comment` | No | Internal staff comment |
+| `patient_instructions` | No | Public patient-facing instructions |
+| `contact` / `contact_number` | No | Contact person and phone |
+| `visible_date` | No | Portal visibility date |
+| `waitlist_duedate` | No | Waitlist due date |
+| `confirmed` | No | 0 or 1 |
+| `canceled` | No | 0, 1 (cancel), or 2 (no-show) |
+| `cancel_code` | No | Cancellation reason code |
+| `remind` | No | Reminder offset in minutes |
+| `ref_id` | No | Referring provider ID(s) |
+| `recurrence` | No | Recurrence type (see enum) |
+| `rc_interval` | No | Recurrence interval |
+| `rc_dow` | No | Day-of-week bitmask |
+| `rc_enddate` | No | Recurrence end date |
+| `interface` / `external_id` | No | External system tracking |
+| `email_pat` | No | 1 = email patient confirmation |
+| `email_resource` | No | 1 = email resource confirmation |
+| `calculate` | No | 1 = recalculate duration from types |
+| `force` | No | 1 = override forceable validation warnings |
+
+**Response:** Appointment ID of the created/updated record.
+
+**Business logic:**
+- Validates patient access permissions (`EC_PatientPermissionCheck`)
+- Runs `SCHED_ValidateApt()` (see [Validation Rules](#validation-rules))
+- Populates junction tables: `multi_resource_apt`, `multi_type_apt`, `multi_referrer_apt`
+- Creates an audit record in `appointment_revisions`
+- Optionally emails confirmation to patient and/or resource
+
+---
+
+## Code Map
+
+### Header Files
+
+| File | Purpose |
+|------|---------|
+| [include/schedulerdb.h](../include/schedulerdb.h) | DB structs (`APPOINTMENT`, `SCHEDULE`, `APT_TYPE`, `APPTMEETING`), column macros, CRUD function declarations, validation enums |
+| [include/scheduler.h](../include/scheduler.h) | UI structs (`SCHED_OPTIONS`, `SCHED_PREF_SECS`), view mode constants, display enums |
+| [include/wcsched.h](../include/wcsched.h) | Layout-driven scheduler (`WCSCHED`, `WCSCHEDPERMS`), view enum (`SCHED_VIEW`) |
+| [include/schlogic.h](../include/schlogic.h) | Time matrix engine (`USAGELIST`), recurrence iteration, free-slot finding |
+| [include/checkindb.h](../include/checkindb.h) | Check-in tracking (`PATLOCATION_BUF`), station management |
+| [include/sched_resource_restrictions.h](../include/sched_resource_restrictions.h) | Resource-level access control |
+
+### Source Files
+
+| File | Purpose |
+|------|---------|
+| [src/schedulerdb.c](../src/schedulerdb.c) | Database CRUD: `DBInsertAppointment()`, `DBUpdateAppointment()`, `DBCancelAppointment()`, `DBInsertSchedule()`, `DBUpdateSchedule()` |
+| [src/scheduler.c](../src/scheduler.c) | Main scheduler handler: `SCHED_Handler()`, preference loading, view routing |
+| [src/schlogic.c](../src/schlogic.c) | Time matrix engine, recurrence expansion, availability checking |
+| [src/api/appointments.c](../src/api/appointments.c) | JSON API for appointments: `ApptMeetingFill()`, appointment creation/update |
+| [src/appointmentreport.c](../src/appointmentreport.c) | Appointment report generation |
+| [src/checkindb.c](../src/checkindb.c) | Check-in database operations |
+| [src/sched_resource_restrictions.c](../src/sched_resource_restrictions.c) | Resource restriction enforcement |
+| [src/schedsync.c](../src/schedsync.c) | Schedule synchronization with external systems |
+
+### JavaScript
+
+| File | Purpose |
+|------|---------|
+| [jsbin/scheduler.js](../jsbin/scheduler.js) | Client-side scheduler logic: view constants, drug eligibility, preference management |
+| [jsbin/schedtemplate.js](../jsbin/schedtemplate.js) | Schedule template UI |
+| [jsbin/due_list_sched.js](../jsbin/due_list_sched.js) | Due list scheduler integration |
+
+### Layouts (MIEstache Templates)
+
+All in `system/layouts/Scheduler/`:
+
+| Layout | Purpose |
+|--------|---------|
+| `Scheduler.html` | Main scheduler UI — Mobiscroll calendar, resource sidebar, location picker |
+| `Appointment Screen.html` | Edit existing appointment — form with patient, types, resources, encounters |
+| `NewApptScreen.html` | Create new appointment — simplified form with portal limits |
+| `Schedules.html` | Schedule management grids — active, past, deleted views |
+| `ApptsAndSchedules.html` | Combined appointments and schedules view |
+| `SchedulesThatAllowApptWin.html` | Schedules with open appointment windows |
+| `ResourceGroups.html` | Resource group management |
+| `ResourcePicker.html` | Resource selection UI |
+| `RecurWin.html` | Recurrence configuration dialog |
+| `GuidedTimeTemplate.html` | Guided time slot template creation |
+| `PopulateHours.html` | Hour population helper |
+| `View Printable Apt.html` | Print-friendly appointment view |
+| `AppointmentCaseDetails.html` | Case/incident details for an appointment |
+| `CSS.html` | Scheduler-specific CSS |
+
+### SQL Reports
+
+| Report | Purpose |
+|--------|---------|
+| `system/reports/Appointments.sql` | Base appointment query |
+| `system/reports/Appointment Reports.sql` | Appointment report with date range filtering |
+| `system/reports/Appointment Types.sql` | Appointment type catalog |
+| `system/reports/Appointment Cancellation Codes.sql` | Cancel code lookup |
+| `system/reports/Appointment Type Templates.sql` | Type template overrides |
+| `system/reports/Appointment Report Revisions.sql` | Revision audit trail |
+| `system/reports/Schedules_Active.sql` | Active schedules |
+| `system/reports/Schedules_Past.sql` | Expired schedules |
+| `system/reports/Schedules_Deleted.sql` | Soft-deleted schedules |
+| `system/reports/ScheduledApptReminder.sql` | Appointment reminder queries |
+
+---
+
+## Scheduler Views
+
+The scheduler supports multiple display modes, defined in [include/scheduler.h](../include/scheduler.h):
+
+| Constant | Value | View |
+|----------|-------|------|
+| `VIEW_DAY` | 1 | Single-day column view |
+| `VIEW_WEEK` | 2 | Full week grid |
+| `VIEW_MONTH` | 3 | Month calendar |
+| `VIEW_YEAR` | 4 | Year overview |
+| `VIEW_MULTI` | 5 | Multi-resource side-by-side |
+| `VIEW_SCHEDULES` | 6 | Schedule template management |
+| `VIEW_APT_TYPES` | 7 | Appointment type editor |
+| `VIEW_WIZARD` | 8 | Scheduling wizard |
+| `VIEW_PRINTABLE` | 9 | Print-friendly view |
+| `VIEW_LIST` | 10 | Appointment list (tabular) |
+
+### Display Modes
+
+| Constant | Value | Shows |
+|----------|-------|-------|
+| `DISP_MERGED` | 1 | Appointments overlaid on schedule templates |
+| `DISP_APTS` | 2 | Appointments only |
+| `DISP_SCHS` | 4 | Schedule templates only |
+| `DISP_ABSORB` | 8 | Absorbed overbooking display |
+| `DISP_APTLIST` | 32 | Appointment list display |
+
+---
+
+## Scheduler Preferences (`SCHED_PREF_SECS`)
+
+The scheduler is highly configurable per user. Key preference categories (defined in [include/scheduler.h](../include/scheduler.h)):
+
+### Display Preferences
+
+| Preference | Description |
+|------------|-------------|
+| `auto_scroll` | Auto-scroll to current time |
+| `dispcomment` | Show appointment comments |
+| `showconfirmed` | Show confirmation status |
+| `showlocation` | Show location column |
+| `show_dob` | Show patient date of birth |
+| `show_canceled` | Show canceled appointments |
+| `show_time_emptycell` | Show time labels on empty cells |
+| `compact_apt` | Compact appointment display |
+| `color_apt` | Color appointments by type |
+| `use_thin_list` | Thin list view |
+| `refresh_minutes` | Auto-refresh interval |
+
+### Feature Toggles
+
+| Preference | Description |
+|------------|-------------|
+| `use_checkin` | Enable check-in buttons |
+| `show_print_label` | Show print label option |
+| `adddict` | Show add-dictation button |
+| `add_trans` | Show add-transcription button |
+| `add_task` | Show add-task button |
+| `add_vitals` | Show add-vitals button |
+| `add_encounter` | Show add-encounter button |
+| `add_order` | Show add-order button |
+| `apt_types` | Show appointment types column |
+| `pat_insurance` | Show patient insurance |
+| `ref_physician` | Show referring physician |
+| `who_scheduled` | Show who scheduled |
+
+### Permissions
+
+| Preference | Description |
+|------------|-------------|
+| `perm_viewapt` | Can view appointments |
+| `perm_addapt` | Can add appointments |
+| `perm_editapt` | Can edit appointments |
+| `perm_viewsch` | Can view schedules |
+| `perm_addsch` | Can add schedule templates |
+| `perm_editsch` | Can edit schedule templates |
+| `perm_adddict` | Can add dictation |
+| `perm_checkin` | Can check in patients |
+| `perm_viewapttypes` | Can view/manage appointment types |
+| `perm_editcancelcode` | Can edit cancellation codes |
+| `restrict_department` | Restrict to department resources |
+
+---
+
+## Template Variables
+
+When rendering forms and layouts via the MIEstache engine, appointment data is available through the `wcd.apt.*` namespace. See [ecform.md](ecform.md#L834) for full details.
+
+| Variable | Description | Example |
+|----------|-------------|---------|
+| `wcd.apt.apt_id` | Appointment ID | `54321` |
+| `wcd.apt.startdate` | Start date | `11/15/2023` |
+| `wcd.apt.starttime` | Start time | `09:00 AM` |
+| `wcd.apt.startdatetime` | Start date and time | `11/15/2023 09:00 AM` |
+| `wcd.apt.enddate` | End date | `11/15/2023` |
+| `wcd.apt.endtime` | End time | `09:30 AM` |
+| `wcd.apt.duration` | Duration (minutes) | `30` |
+| `wcd.apt.apt_type` | Appointment type description | `Office Visit` |
+| `wcd.apt.apt_type_code` | Appointment type code | `OV` |
+| `wcd.apt.location` | Location name | `Main Clinic` |
+| `wcd.apt.resource` | Primary resource name | `Dr. Wilson` |
+| `wcd.apt.resource.<field>` | Resource user field | Any user field |
+| `wcd.apt.resource.N.<field>` | Nth resource field | `wcd.apt.resource.1.full_name` |
+| `wcd.apt.resource.all.<field>` | All resources | Combined list |
+| `wcd.apt.all_resources` | All resource names | Multi-line list |
+| `wcd.apt.comment` | Internal comment | Free text |
+| `wcd.apt.status` | Status string | `Scheduled` |
+| `wcd.apt.arrived` | Arrival time | `08:55 AM` |
+| `wcd.apt.checked_in` | Check-in time | `09:00 AM` |
+| `wcd.apt.checked_out` | Check-out time | `09:35 AM` |
+| `wcd.apt.patient_name` | Patient name | `John Smith` |
+| `wcd.apt.patient.<field>` | Patient field | Any patient field |
+
+---
+
+## Time Matrix Engine (`USAGELIST`)
+
+The core scheduling algorithm in [include/schlogic.h](../include/schlogic.h) uses a time matrix to manage availability:
+
+1. **`USAGELISTCreate()`** — Allocates a time grid with configurable cell duration (e.g., 15-minute cells)
+2. **`USAGELISTAddBlock()`** — Adds appointment or schedule blocks into the matrix with conflict detection
+3. **`USAGELISTFindFree()`** — Searches for open slots matching appointment type, location, and portal constraints
+4. **`USAGELISTIsOpen()`** — Checks if a specific time slot is available (respects overbooking limits)
+5. **`Sched_IsApptSlotAvailable()`** — High-level check combining matrix lookup with business rules
+
+The matrix supports multiple resources as columns and time increments as rows, enabling the side-by-side multi-resource scheduler view.
+
+---
+
+## External System Integration
+
+### HL7 (SIU Messages)
+
+- `Appointment2hl7()` in [interfaces/wc-data_send/](../interfaces/wc-data_send/) converts appointments to HL7 SIU messages
+- `interface` field tracks origin system
+- `external_id` stores the foreign key
+- `filler_status_code` maps HL7 appointment status
+
+### Sync
+
+- [src/schedsync.c](../src/schedsync.c) handles bidirectional schedule synchronization
+- `interface` + `external_id` uniquely identify external appointments
+- `DBGetAptIDsByPatIDExtIDInterface()` resolves duplicates during sync
+
+---
+
+## Seed Data
+
+[deploy/postsql/schedules.sql](../deploy/postsql/schedules.sql) inserts default schedule blocks for all users in the `Scheduling Resources` realm:
+
+- Hourly blocks from 08:00–16:00
+- Location: `OFFICE`
+- Recurrence: weekly (`2`), interval `1`, Sunday (`rc_dow=1`)
+- Overbooking: `1`
+- Associated appointment type: `OFFVISITEST` via `multi_type_sched`

--- a/docs/scheduling-models.md
+++ b/docs/scheduling-models.md
@@ -1,0 +1,624 @@
+# Scheduling Models: Schedule vs Slot
+
+> **TL;DR** — Legacy systems model availability in two fundamentally different ways.
+> FHIRTogether accepts both and normalizes them into FHIR `Slot` resources
+> ready for booking and SMART Scheduling Links compliance.
+
+---
+
+## 1. Overview: Two Scheduling Models
+
+Healthcare scheduling systems fall into two camps:
+
+| | **Slot-Based** | **Schedule-Based** |
+|---|---|---|
+| **Philosophy** | Concrete, precomputed availability | Rules that *describe* availability |
+| **Data shape** | A row per bookable time block | Recurrence rules, durations, exceptions |
+| **Generation** | Slots exist before anyone asks | Slots are derived on demand |
+| **Example** | "Dr. Smith has a 9:00 AM slot on Monday" | "Dr. Smith sees patients Mon–Fri, 8–5, every 20 min" |
+
+Both are valid. Both are common. The difference matters when you integrate.
+
+```mermaid
+graph LR
+    subgraph "Slot-Based System"
+        DB[(Slot Database)] --> S1[Slot 9:00]
+        DB --> S2[Slot 9:20]
+        DB --> S3[Slot 9:40]
+    end
+
+    subgraph "Schedule-Based System"
+        Rules[Availability Rules] -->|generate| S4[Slot 9:00]
+        Rules -->|generate| S5[Slot 9:20]
+        Rules -->|generate| S6[Slot 9:40]
+    end
+
+    S1 & S4 --> FHIR[FHIR Slot Resource]
+
+    classDef slot fill:#4CAF50,color:#fff
+    classDef rule fill:#2196F3,color:#fff
+    classDef fhir fill:#FF9800,color:#fff
+    class S1,S2,S3,S4,S5,S6 slot
+    class Rules rule
+    class FHIR fhir
+```
+
+---
+
+## 2. Identify Your System Type
+
+### ✅ You have a **Slot-Based** system if:
+
+- [ ] Your database has a table of time slots with start/end times
+- [ ] Availability is precomputed (nightly batch, admin UI, etc.)
+- [ ] Booking means claiming an existing row
+- [ ] You can export a list of "open appointments"
+
+**Examples:** Many EHR appointment books, clinic scheduling modules, OpenMRS
+
+### ✅ You have a **Schedule-Based** system if:
+
+- [ ] Providers define working hours and appointment durations
+- [ ] Available times are calculated from rules, not stored
+- [ ] You use concepts like "recurrence," "templates," or "block schedules"
+- [ ] There's no explicit slot table — availability is derived
+
+**Examples:** Google Calendar-style systems, rule-engine schedulers, some enterprise EHRs
+
+### ✅ You have a **Hybrid** system if:
+
+- [ ] Rules generate slots, but slots are then persisted
+- [ ] Some availability is manual, some is rule-driven
+
+> **FHIRTogether itself is a hybrid** — it stores concrete Slot resources
+> but can accept them from either upstream model.
+
+---
+
+## 3. Integration Path: Slot-Based Systems
+
+> *"If you already have slots, you're 80% done."*
+
+### Step 1: Map your slots to FHIR
+
+Your existing slot data maps directly to a FHIR `Slot` resource:
+
+```json
+{
+  "resourceType": "Slot",
+  "schedule": { "reference": "Schedule/dr-smith-family-med" },
+  "status": "free",
+  "start": "2026-05-01T09:00:00Z",
+  "end": "2026-05-01T09:20:00Z",
+  "serviceType": [{ "text": "Family Medicine" }]
+}
+```
+
+| Your field | FHIR Slot field | Notes |
+|---|---|---|
+| Provider ID | `schedule.reference` | Create a Schedule per provider first |
+| Start time | `start` | ISO 8601 datetime |
+| End time | `end` | ISO 8601 datetime |
+| Available? | `status` | `free`, `busy`, `busy-unavailable`, `busy-tentative` |
+| Appointment type | `serviceType` | CodeableConcept array |
+
+### Step 2: Create a Schedule for each provider
+
+Every Slot must reference a Schedule. Create one per provider:
+
+```json
+{
+  "resourceType": "Schedule",
+  "actor": [
+    {
+      "reference": "Practitioner/practitioner-smith",
+      "display": "Dr. Sarah Smith"
+    }
+  ],
+  "serviceType": [{ "text": "Family Medicine" }],
+  "planningHorizon": {
+    "start": "2026-05-01",
+    "end": "2026-10-28"
+  },
+  "comment": "Schedule for Dr. Sarah Smith"
+}
+```
+
+### Step 3: Push to FHIRTogether
+
+```bash
+# Create the schedule
+curl -X POST http://localhost:4010/Schedule \
+  -H "Content-Type: application/json" \
+  -d @schedule.json
+
+# Create slots (one per available time)
+curl -X POST http://localhost:4010/Slot \
+  -H "Content-Type: application/json" \
+  -d @slot.json
+```
+
+### Step 4: Verify
+
+```bash
+# List free slots for a schedule
+curl "http://localhost:4010/Slot?schedule=Schedule/dr-smith-family-med&status=free"
+```
+
+Response is a FHIR Bundle:
+
+```json
+{
+  "resourceType": "Bundle",
+  "type": "searchset",
+  "total": 42,
+  "entry": [
+    {
+      "resource": {
+        "resourceType": "Slot",
+        "id": "slot-001",
+        "schedule": { "reference": "Schedule/dr-smith-family-med" },
+        "status": "free",
+        "start": "2026-05-01T09:00:00.000Z",
+        "end": "2026-05-01T09:20:00.000Z"
+      }
+    }
+  ]
+}
+```
+
+**That's it.** Your slots are now FHIR-compliant and bookable.
+
+---
+
+## 4. Integration Path: Schedule-Based Systems
+
+> *"You don't need to precompute slots — FHIRTogether does it for you."*
+
+If your system defines availability as rules rather than concrete slots,
+you need to **generate slots** from those rules before pushing to FHIRTogether.
+
+### Step 1: Create a FHIR Schedule for the provider
+
+```bash
+curl -X POST http://localhost:4010/Schedule \
+  -H "Content-Type: application/json" \
+  -d '{
+    "resourceType": "Schedule",
+    "actor": [{ "reference": "Practitioner/practitioner-williams", "display": "Dr. Amy Williams" }],
+    "serviceType": [{ "text": "Pediatrics" }],
+    "planningHorizon": { "start": "2026-05-01", "end": "2026-10-28" },
+    "comment": "Pediatrics — Mon-Fri 8am-4pm, 15 min slots"
+  }'
+```
+
+### Step 2: Define availability with the Schedule YAML format
+
+FHIRTogether uses a simple YAML format to describe recurring availability.
+This is the **same format** used by the HL7 Tester's slot builder, the
+`generateBusyOffice.ts` data generator, and the planned YAML import API.
+
+#### Minimal example
+
+```yaml
+# Schedule definition for Dr. Amy Williams
+# Schedule: Schedule/<id-from-step-1>
+
+startDate: "2026-05-01"
+endDate:   "2026-10-28"
+weekdays:  [mon, tue, wed, thu, fri]
+
+blocks:
+  - start: "08:00"
+    end:   "12:00"
+    duration: 15    # minutes per slot
+  - start: "13:00"
+    end:   "16:00"
+    duration: 15
+```
+
+#### Full example with appointment types and overbooking
+
+```yaml
+startDate: "2026-05-01"
+endDate:   "2026-10-28"
+weekdays:  [mon, tue, wed, thu, fri]
+
+# Define appointment types (maps to WebChart apt_types table)
+appointmentTypes:
+  - code: OV
+    description: "Office Visit"
+    duration: 30
+  - code: FU
+    description: "Follow-Up"
+    duration: 15
+  - code: NP
+    description: "New Patient"
+    duration: 45
+
+blocks:
+  - start: "08:00"
+    end:   "12:00"
+    duration: 30
+    types: [OV, FU, NP]    # allowed appointment types for this block
+    overbook: 2             # max concurrent overbookings
+  - start: "13:00"
+    end:   "16:00"
+    duration: 15
+    types: [FU]             # afternoon = follow-ups only
+    overbook: 0             # no overbooking
+```
+
+#### Field reference
+
+| YAML field | Purpose | FHIR Slot field | Example |
+|---|---|---|---|
+| `startDate` | First day of the availability window | — (controls generation range) | `"2026-05-01"` |
+| `endDate` | Last day of the availability window | — (controls generation range) | `"2026-10-28"` |
+| `weekdays` | Which days to generate slots | — (controls generation range) | `[mon, wed, fri]` |
+| `appointmentTypes[].code` | Short identifier for visit type | — (lookup key) | `OV` |
+| `appointmentTypes[].description` | Display name | `appointmentType.text` | `"Office Visit"` |
+| `appointmentTypes[].duration` | Default minutes for this type | — (can override block duration) | `30` |
+| `blocks[].start` | Block start time (24h) | — (generates `start`) | `"08:00"` |
+| `blocks[].end` | Block end time (24h) | — (generates `end`) | `"12:00"` |
+| `blocks[].duration` | Slot length in minutes | `end` - `start` per slot | `15` |
+| `blocks[].types` | Allowed appointment types | `appointmentType`, `serviceType[]` | `[OV, FU]` |
+| `blocks[].overbook` | Max concurrent overbookings | `overbooked`, `comment` | `2` |
+
+Multiple blocks model lunch breaks and split shifts naturally —
+the gap between 12:00 and 13:00 above is the lunch hour.
+
+### Step 3: Generate slots from the YAML
+
+The YAML expands into individual FHIR Slot resources. You can use:
+
+- **HL7 Tester UI** → Send an SIU message, then click **Generate Slots** and
+  paste your YAML. The browser creates slots via `POST /Slot` directly.
+- **Programmatically** — the expansion logic is straightforward:
+
+```typescript
+// Same algorithm used by hl7-tester.html and generateBusyOffice.ts
+for (let day = startDate; day <= endDate; day = nextDay(day)) {
+  if (!weekdays.includes(day.getDay())) continue;
+
+  for (const block of blocks) {
+    let current = setTime(day, block.start);
+    const blockEnd = setTime(day, block.end);
+
+    while (current + block.duration <= blockEnd) {
+      await POST('/Slot', {
+        resourceType: 'Slot',
+        schedule: { reference: `Schedule/${scheduleId}` },
+        status: 'free',
+        start: current.toISOString(),
+        end: addMinutes(current, block.duration).toISOString(),
+      });
+      current = addMinutes(current, block.duration);
+    }
+  }
+}
+```
+
+### Step 4: Handle exceptions
+
+Real schedules have exceptions (holidays, vacations).
+Mark those slots as unavailable:
+
+```json
+{
+  "resourceType": "Slot",
+  "schedule": { "reference": "Schedule/dr-williams-peds" },
+  "status": "busy-unavailable",
+  "start": "2026-07-04T08:00:00Z",
+  "end": "2026-07-04T16:00:00Z",
+  "comment": "Holiday — Independence Day"
+}
+```
+
+### Mapping from WebChart and other legacy EHRs
+
+Enterprise EHRs like WebChart express availability through schedule templates,
+appointment types, recurrence rules, and overbooking settings. Here's how each
+concept maps to the Schedule YAML and FHIR resources.
+
+#### Schedule template → YAML blocks
+
+WebChart's `schedules` table defines availability as time blocks with recurrence:
+
+| WebChart `schedules` column | Schedule YAML | Notes |
+|---|---|---|
+| `startdate` / `enddate` (time portion) | `blocks[].start` / `blocks[].end` | Working hours for the block |
+| `startdate` / `rc_enddate` (date portion) | `startDate` / `endDate` | Date range for the availability window |
+| `rc_dow` (day-of-week bitmask) | `weekdays: [mon, wed, fri]` | Mon=2, Tue=4, Wed=8, etc. → named days |
+| `num_overbook` | `blocks[].overbook` | Max concurrent overbookings |
+| `num_total_apts` | — | Enforce via slot count per block |
+| `absorb` | — | Controls whether overbooking absorbs into adjacent slots |
+| `portal_time_slots` | — | Controls patient portal visibility (future) |
+| `recurrence` / `rc_interval` | Implicit in `startDate`→`endDate` + `weekdays` | YAML generates all days; recurrence is "expanded" |
+| `location` | FHIR `Schedule.actor[]` with Location reference | Add a Location actor alongside the Practitioner |
+| `color` | — | Display concern, not scheduling data |
+
+#### Appointment types → `appointmentTypes`
+
+WebChart's `apt_types` table maps directly:
+
+| WebChart `apt_types` column | Schedule YAML | FHIR Slot field |
+|---|---|---|
+| `code` | `appointmentTypes[].code` | — (lookup key) |
+| `description` | `appointmentTypes[].description` | `appointmentType.text` |
+| `duration` | `appointmentTypes[].duration` | `end` - `start` |
+| `pat_duration` | — | Patient-visible duration (future) |
+| `portal_available` | — | Controls portal visibility (future) |
+| `color` | — | Display concern |
+| `enc_type` | — | Encounter creation, outside scheduling scope |
+
+#### Per-schedule type restrictions → `blocks[].types`
+
+WebChart's `multi_type_sched` junction table controls which appointment types
+are allowed in each schedule block:
+
+| WebChart `multi_type_sched` column | Schedule YAML |
+|---|---|
+| `type` (FK → `apt_types.code`) | `blocks[].types: [OV, FU]` |
+| `required` | — (all listed types are available) |
+| `portal_available` | — (future) |
+
+#### Per-resource overrides → separate YAML files
+
+WebChart's `apt_type_templates` table allows overriding durations per resource
+and location. In FHIRTogether, each provider gets their own Schedule + YAML,
+so resource-specific overrides are just different YAML files:
+
+```yaml
+# Dr. Williams — Pediatrics (shorter visits)
+appointmentTypes:
+  - code: OV
+    description: "Office Visit"
+    duration: 15          # 15 min for peds vs 30 min for family med
+```
+
+#### Recurrence expansion
+
+WebChart uses `RC_TYPE` enums (daily, weekly, monthly, nth-weekday, etc.)
+with `rc_interval`, `rc_dow` bitmask, and `rc_enddate`. The Schedule YAML
+"expands" these into a flat date range + weekday list:
+
+| WebChart recurrence | Schedule YAML equivalent |
+|---|---|
+| `RC_WEEKLY` + `rc_dow=42` (Mon+Wed+Fri) + `rc_interval=1` | `weekdays: [mon, wed, fri]` |
+| `RC_WEEKLY` + `rc_dow=62` (Mon–Fri) + `rc_interval=2` | Not yet supported (bi-weekly) — use two YAML files |
+| `RC_DAILY` + `rc_interval=1` | `weekdays: [mon, tue, wed, thu, fri, sat, sun]` |
+| `rc_enddate` | `endDate` |
+
+> **Note:** The YAML format currently supports weekly recurrence (the most
+> common pattern). Monthly, bi-weekly, and nth-weekday patterns require
+> generating the specific dates and creating slots individually.
+
+---
+
+## 5. Unified Model in FHIRTogether
+
+Regardless of how availability enters the system, FHIRTogether normalizes
+everything into three FHIR R4 resources:
+
+```mermaid
+graph TB
+    subgraph "Input Sources"
+        SlotSys[Slot-Based System]
+        SchedSys[Schedule-Based System]
+        Manual[Manual Entry]
+    end
+
+    subgraph FHIRTogether["FHIRTogether Gateway"]
+        API[REST API]
+        Store[(SQLite Store)]
+        Sched[Schedule Resources]
+        Slots[Slot Resources]
+        Appts[Appointment Resources]
+    end
+
+    subgraph "Output"
+        FHIRAPI[FHIR R4 API]
+        SSL[SMART Scheduling Links]
+        HL7[HL7v2 SIU Messages]
+    end
+
+    SlotSys -->|POST /Slot| API
+    SchedSys -->|generate + POST /Slot| API
+    Manual -->|POST /Slot| API
+
+    API --> Store
+    Store --> Sched & Slots & Appts
+
+    Sched & Slots & Appts --> FHIRAPI
+    Slots --> SSL
+    Appts --> HL7
+
+    classDef input fill:#2196F3,color:#fff
+    classDef core fill:#4CAF50,color:#fff
+    classDef output fill:#FF9800,color:#fff
+    class SlotSys,SchedSys,Manual input
+    class API,Store,Sched,Slots,Appts core
+    class FHIRAPI,SSL,HL7 output
+```
+
+### The three resources
+
+| Resource | Purpose | Relationship |
+|---|---|---|
+| **Schedule** | Container for a provider's availability window | Has many Slots |
+| **Slot** | A single bookable time block | Belongs to a Schedule; referenced by Appointments |
+| **Appointment** | A committed booking | References one or more Slots; has Participants |
+
+### How booking works
+
+```mermaid
+sequenceDiagram
+    participant Patient
+    participant FT as FHIRTogether
+    participant Store as SQLite
+
+    Patient->>FT: GET /Slot?status=free&schedule=Schedule/123
+    FT->>Store: Query free slots
+    Store-->>FT: Slot list
+    FT-->>Patient: FHIR Bundle (free slots)
+
+    Patient->>FT: POST /Appointment (slot reference + participant)
+    FT->>Store: Create Appointment, mark Slot busy
+    Store-->>FT: Created
+    FT-->>Patient: Appointment (PHI redacted)
+```
+
+---
+
+## 6. SMART Scheduling Links Compatibility
+
+[SMART Scheduling Links](https://build.fhir.org/ig/HL7/smart-scheduling-links/)
+is the emerging standard for publishing vaccine and appointment availability.
+It expects **Slot resources only** — no proprietary availability formats.
+
+### What SMART Scheduling Links requires
+
+1. **Location** — where appointments happen
+2. **Schedule** — who/what is available
+3. **Slot** — concrete bookable times with status
+4. **`$bulk-publish`** — NDJSON manifest of the above
+
+### How FHIRTogether bridges the gap
+
+| If your system has… | FHIRTogether provides… |
+|---|---|
+| Precomputed slots | Direct FHIR Slot exposure |
+| Availability rules | A pattern for generating compliant Slots |
+| Neither | A complete scheduling backend with FHIR-native storage |
+
+> **Future:** FHIRTogether plans to add a `$bulk-publish` endpoint that
+> generates the NDJSON manifest automatically from stored Slots.
+> Track progress in [GitHub Issues](https://github.com/mieweb/FHIRTogether/issues).
+
+### Compliance checklist
+
+- [x] Slot resources with `status`, `start`, `end`
+- [x] Schedule resources with `actor` references
+- [x] FHIR R4 Bundle responses for search
+- [ ] `$bulk-publish` endpoint (planned)
+- [ ] Location resources (planned)
+
+---
+
+## 7. Migration & Adoption Guidance
+
+### Decision tree
+
+```mermaid
+flowchart TD
+    Start([Start Here]) --> Q1{Do you have a<br/>slot/appointment table?}
+
+    Q1 -->|Yes| SlotPath[Slot-Based Path]
+    Q1 -->|No| Q2{Do you have<br/>availability rules?}
+
+    Q2 -->|Yes| SchedPath[Schedule-Based Path]
+    Q2 -->|No| FreshPath[Fresh Start]
+
+    SlotPath --> S1["1. Create Schedule per provider<br/>(POST /Schedule)"]
+    S1 --> S2["2. Map slots → FHIR Slot<br/>(POST /Slot)"]
+    S2 --> S3["3. Verify with GET /Slot?status=free"]
+    S3 --> Done([Ready for Booking])
+
+    SchedPath --> R1["1. Create Schedule per provider<br/>(POST /Schedule)"]
+    R1 --> R2["2. Write slot generator<br/>(rules → Slot resources)"]
+    R2 --> R3["3. POST generated slots"]
+    R3 --> R4["4. Handle exceptions<br/>(holidays, vacations)"]
+    R4 --> Done
+
+    FreshPath --> F1["1. Use generateBusyOffice.ts<br/>as a starting template"]
+    F1 --> F2["2. Customize providers,<br/>hours, durations"]
+    F2 --> Done
+
+    classDef start fill:#9C27B0,color:#fff
+    classDef decision fill:#FF9800,color:#fff
+    classDef path fill:#2196F3,color:#fff
+    classDef step fill:#4CAF50,color:#fff
+    classDef done fill:#4CAF50,color:#fff
+    class Start start
+    class Q1,Q2 decision
+    class SlotPath,SchedPath,FreshPath path
+    class S1,S2,S3,R1,R2,R3,R4,F1,F2 step
+    class Done done
+```
+
+### Quick-start paths
+
+#### Path A: I have slots (5 minutes)
+
+```bash
+# 1. Start FHIRTogether
+npm run dev
+
+# 2. Create a schedule
+curl -X POST http://localhost:4010/Schedule \
+  -H "Content-Type: application/json" \
+  -d '{"resourceType":"Schedule","actor":[{"reference":"Practitioner/dr-1","display":"Dr. Example"}],"planningHorizon":{"start":"2026-05-01","end":"2026-10-28"}}'
+
+# 3. Push your slots (repeat for each slot)
+curl -X POST http://localhost:4010/Slot \
+  -H "Content-Type: application/json" \
+  -d '{"resourceType":"Slot","schedule":{"reference":"Schedule/<id-from-step-2>"},"status":"free","start":"2026-05-01T09:00:00Z","end":"2026-05-01T09:20:00Z"}'
+
+# 4. Book an appointment
+curl -X POST http://localhost:4010/Appointment \
+  -H "Content-Type: application/json" \
+  -d '{"resourceType":"Appointment","status":"booked","slot":[{"reference":"Slot/<id-from-step-3>"}],"participant":[{"actor":{"reference":"Practitioner/dr-1"},"status":"accepted"},{"actor":{"reference":"Patient/patient-1"},"status":"accepted"}]}'
+```
+
+#### Path B: I have rules (5 minutes with HL7 Tester)
+
+1. Start FHIRTogether: `npm run dev`
+2. Open the HL7 Tester: `http://localhost:4010/hl7-tester.html`
+3. Send an SIU^S12 message to register a provider
+4. Click **Generate Slots** and edit the YAML to match your provider's hours:
+   ```yaml
+   startDate: "2026-05-01"
+   endDate:   "2026-10-28"
+   weekdays:  [mon, tue, wed, thu, fri]
+
+   appointmentTypes:
+     - code: OV
+       description: "Office Visit"
+       duration: 30
+
+   blocks:
+     - start: "08:00"
+       end:   "12:00"
+       duration: 30
+       types: [OV]
+     - start: "13:00"
+       end:   "16:00"
+       duration: 30
+       types: [OV]
+   ```
+5. Click **Create Slots** — done!
+
+For programmatic generation, see `src/examples/generateBusyOffice.ts`
+which uses the same block/duration/weekday model.
+
+#### Path C: Starting fresh (2 minutes)
+
+```bash
+npm install
+npm run generate-data   # Creates 3 providers, 180 days of slots, 75% booked
+npm run dev             # API ready at http://localhost:4010
+open http://localhost:4010/docs  # Swagger UI
+```
+
+---
+
+## Further Reading
+
+- [QUICKSTART.md](../QUICKSTART.md) — Setup and first run
+- [ARCHITECTURE.md](../ARCHITECTURE.md) — System design and ER diagram
+- [IMPLEMENTATION.md](../IMPLEMENTATION.md) — Endpoint reference
+- [src/examples/README.md](../src/examples/README.md) — Data generation guide
+- [FHIR R4 Slot](https://hl7.org/fhir/R4/slot.html) — Official specification
+- [FHIR R4 Schedule](https://hl7.org/fhir/R4/schedule.html) — Official specification
+- [SMART Scheduling Links](https://build.fhir.org/ig/HL7/smart-scheduling-links/) — Availability publishing standard

--- a/docs/scheduling-models.md
+++ b/docs/scheduling-models.md
@@ -249,6 +249,34 @@ blocks:
     overbook: 0             # no overbooking
 ```
 
+#### RRULE example: bi-weekly clinic
+
+For schedules that don't follow a simple weekly pattern, use an
+[RFC 5545 RRULE](https://datatracker.ietf.org/doc/html/rfc5545#section-3.3.10)
+string instead of `weekdays`. The `rrule` field takes precedence over `weekdays`.
+
+```yaml
+startDate: "2026-05-01"
+endDate:   "2026-10-28"
+rrule: "FREQ=WEEKLY;INTERVAL=2;BYDAY=MO,WE,FR"   # every other week
+exdates: [2026-07-04, 2026-09-07]                  # skip holidays
+
+blocks:
+  - start: "08:00"
+    end:   "12:00"
+    duration: 30
+```
+
+Common RRULE patterns:
+
+| Pattern | RRULE | Notes |
+|---|---|---|
+| Every weekday | `FREQ=WEEKLY;BYDAY=MO,TU,WE,TH,FR` | Same as `weekdays: [mon–fri]` |
+| Bi-weekly Mon/Wed/Fri | `FREQ=WEEKLY;INTERVAL=2;BYDAY=MO,WE,FR` | Alternating weeks |
+| First Monday of month | `FREQ=MONTHLY;BYDAY=1MO` | Monthly specialist clinic |
+| Last Friday of month | `FREQ=MONTHLY;BYDAY=-1FR` | End-of-month reviews |
+| Every 3rd day | `FREQ=DAILY;INTERVAL=3` | Rotating coverage |
+
 #### Field reference
 
 | YAML field | Purpose | FHIR Slot field | Example |
@@ -256,6 +284,8 @@ blocks:
 | `startDate` | First day of the availability window | — (controls generation range) | `"2026-05-01"` |
 | `endDate` | Last day of the availability window | — (controls generation range) | `"2026-10-28"` |
 | `weekdays` | Which days to generate slots | — (controls generation range) | `[mon, wed, fri]` |
+| `rrule` | RFC 5545 recurrence rule (overrides weekdays) | — (controls generation range) | `"FREQ=WEEKLY;INTERVAL=2;BYDAY=MO"` |
+| `exdates` | Dates to exclude (holidays, closures) | — (controls generation range) | `[2026-07-04, 2026-12-25]` |
 | `appointmentTypes[].code` | Short identifier for visit type | — (lookup key) | `OV` |
 | `appointmentTypes[].description` | Display name | `appointmentType.text` | `"Office Visit"` |
 | `appointmentTypes[].duration` | Default minutes for this type | — (can override block duration) | `30` |
@@ -386,13 +416,16 @@ with `rc_interval`, `rc_dow` bitmask, and `rc_enddate`. The Schedule YAML
 | WebChart recurrence | Schedule YAML equivalent |
 |---|---|
 | `RC_WEEKLY` + `rc_dow=42` (Mon+Wed+Fri) + `rc_interval=1` | `weekdays: [mon, wed, fri]` |
-| `RC_WEEKLY` + `rc_dow=62` (Mon–Fri) + `rc_interval=2` | Not yet supported (bi-weekly) — use two YAML files |
+| `RC_WEEKLY` + `rc_dow=62` (Mon–Fri) + `rc_interval=2` | `rrule: "FREQ=WEEKLY;INTERVAL=2;BYDAY=MO,TU,WE,TH,FR"` |
 | `RC_DAILY` + `rc_interval=1` | `weekdays: [mon, tue, wed, thu, fri, sat, sun]` |
+| `RC_MONTHLY` + `rc_dow=2` (Mon) + nth-weekday | `rrule: "FREQ=MONTHLY;BYDAY=1MO"` |
 | `rc_enddate` | `endDate` |
 
-> **Note:** The YAML format currently supports weekly recurrence (the most
-> common pattern). Monthly, bi-weekly, and nth-weekday patterns require
-> generating the specific dates and creating slots individually.
+> **Note:** The `rrule` field supports any valid RFC 5545 recurrence rule,
+> including bi-weekly, monthly, and nth-weekday patterns. The `weekdays`
+> field remains available as a simpler alternative for basic weekly schedules.
+> Use `exdates` to exclude specific dates (holidays, vacations) from any
+> recurrence pattern.
 
 ---
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -19,6 +19,7 @@
         "fastify": "^5.8.5",
         "pino": "^8.17.2",
         "pino-pretty": "^10.3.1",
+        "rrule": "^2.8.1",
         "zod": "^4.3.6"
       },
       "devDependencies": {
@@ -7918,6 +7919,15 @@
         "node": ">= 18"
       }
     },
+    "node_modules/rrule": {
+      "version": "2.8.1",
+      "resolved": "https://registry.npmjs.org/rrule/-/rrule-2.8.1.tgz",
+      "integrity": "sha512-hM3dHSBMeaJ0Ktp7W38BJZ7O1zOgaFEsn41PDk+yHoEtfLV+PoJt9E9xAlZiWgf/iqEqionN0ebHFZIDAp+iGw==",
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "tslib": "^2.4.0"
+      }
+    },
     "node_modules/safe-buffer": {
       "version": "5.2.1",
       "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.1.tgz",
@@ -8753,9 +8763,7 @@
       "version": "2.8.1",
       "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
       "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
-      "dev": true,
-      "license": "0BSD",
-      "optional": true
+      "license": "0BSD"
     },
     "node_modules/tsx": {
       "version": "4.21.0",

--- a/package.json
+++ b/package.json
@@ -39,20 +39,21 @@
     "fastify": "^5.8.5",
     "pino": "^8.17.2",
     "pino-pretty": "^10.3.1",
+    "rrule": "^2.8.1",
     "zod": "^4.3.6"
   },
   "devDependencies": {
+    "@eslint/js": "^9.27.0",
     "@playwright/test": "^1.59.1",
     "@types/better-sqlite3": "^7.6.8",
     "@types/jest": "^30.0.0",
     "@types/node": "^20.10.6",
-    "@eslint/js": "^9.27.0",
     "eslint": "^9.27.0",
-    "typescript-eslint": "^8.32.1",
     "jest": "^30.3.0",
     "ts-jest": "^29.4.9",
     "ts-node": "^10.9.2",
     "tsx": "^4.7.0",
-    "typescript": "^5.3.3"
+    "typescript": "^5.3.3",
+    "typescript-eslint": "^8.32.1"
   }
 }

--- a/packages/fhir-scheduler/src/api/fhirClient.ts
+++ b/packages/fhir-scheduler/src/api/fhirClient.ts
@@ -6,6 +6,8 @@ import type {
   QuestionnaireResponse,
   SlotHold,
   Bundle,
+  AvailabilityTemplate,
+  GenerateSlotsResult,
 } from '../types';
 
 export interface FhirClientConfig {
@@ -37,6 +39,11 @@ export interface FhirClient {
     provider?: Schedule,
     visitType?: string
   ): Promise<Appointment>;
+  generateSlots(
+    scheduleId: string,
+    template: AvailabilityTemplate,
+    mode?: 'replace' | 'incremental'
+  ): Promise<GenerateSlotsResult>;
 }
 
 export function createFhirClient(config: FhirClientConfig): FhirClient {
@@ -254,6 +261,44 @@ export function createFhirClient(config: FhirClientConfig): FhirClient {
       }
       
       return res.json();
+    },
+
+    async generateSlots(
+      scheduleId: string,
+      template: AvailabilityTemplate,
+      mode: 'replace' | 'incremental' = 'replace'
+    ): Promise<GenerateSlotsResult> {
+      const res = await fetch(
+        `${baseUrl}/Schedule/${encodeURIComponent(scheduleId)}/$generate-slots?mode=${mode}`,
+        {
+          method: 'POST',
+          headers: defaultHeaders,
+          body: JSON.stringify({ template }),
+        }
+      );
+
+      const body = await res.json();
+
+      if (!res.ok) {
+        const details = body.details ? body.details.join('; ') : '';
+        throw new Error(body.error + (details ? `: ${details}` : ''));
+      }
+
+      // Parse OperationOutcome extensions
+      const resultExt = (body.extension || []).find(
+        (e: { url: string }) => e.url?.includes('generate-slots-result')
+      );
+      const extMap: Record<string, number | string> = {};
+      for (const e of resultExt?.extension || []) {
+        extMap[e.url] = e.valueInteger ?? e.valueString ?? '';
+      }
+
+      return {
+        slotsCreated: (extMap.slotsCreated as number) || 0,
+        slotsDeleted: (extMap.slotsDeleted as number) || 0,
+        mode: (extMap.mode as string) || mode,
+        warnings: (extMap.warnings as string) || undefined,
+      };
     },
   };
 }

--- a/packages/fhir-scheduler/src/components/ScheduleSetup.tsx
+++ b/packages/fhir-scheduler/src/components/ScheduleSetup.tsx
@@ -1,0 +1,1369 @@
+import { useState, useEffect, useMemo, useCallback } from 'react';
+import { createFhirClient } from '../api/fhirClient';
+import type { Schedule, Bundle, AvailabilityTemplate, AvailabilityBlock, AppointmentTypeDefinition, GenerateSlotsResult } from '../types';
+
+// ==================== Props ====================
+
+interface ScheduleSetupProps {
+  /** Base URL of the FHIR server */
+  fhirBaseUrl: string;
+  /** Pre-select a provider by schedule ID */
+  initialScheduleId?: string;
+  /** Callback when slots are generated successfully */
+  onGenerate?: (result: GenerateSlotsResult) => void;
+}
+
+// ==================== Constants ====================
+
+const WEEKDAYS = ['sun', 'mon', 'tue', 'wed', 'thu', 'fri', 'sat'] as const;
+const WEEKDAY_LABELS: Record<string, string> = {
+  sun: 'Sun', mon: 'Mon', tue: 'Tue', wed: 'Wed', thu: 'Thu', fri: 'Fri', sat: 'Sat',
+};
+const DAY_NUMBERS: Record<string, number> = {
+  sun: 0, mon: 1, tue: 2, wed: 3, thu: 4, fri: 5, sat: 6,
+};
+const DURATION_OPTIONS = [15, 20, 30, 45, 60];
+
+/** Maps weekday abbreviations to RRULE BYDAY tokens */
+const WEEKDAY_TO_BYDAY: Record<string, string> = {
+  sun: 'SU', mon: 'MO', tue: 'TU', wed: 'WE', thu: 'TH', fri: 'FR', sat: 'SA',
+};
+const BYDAY_TO_WEEKDAY: Record<string, string> = {
+  SU: 'sun', MO: 'mon', TU: 'tue', WE: 'wed', TH: 'thu', FR: 'fri', SA: 'sat',
+};
+
+/** Recurrence frequency tabs (Outlook-style) */
+type RecurrenceFreq = 'daily' | 'weekly' | 'monthly' | 'yearly';
+
+/** Daily sub-mode */
+type DailyMode = 'interval' | 'weekdays';
+
+/** Monthly sub-mode */
+type MonthlyMode = 'dayOfMonth' | 'weekdayOfMonth';
+
+/** Yearly sub-mode */
+type YearlyMode = 'exact' | 'relative';
+
+/** Ordinal position for "the Nth weekday" pattern */
+const ORDINALS = [
+  { value: '1', label: 'First' },
+  { value: '2', label: 'Second' },
+  { value: '3', label: 'Third' },
+  { value: '4', label: 'Fourth' },
+  { value: '-1', label: 'Last' },
+];
+
+/** Weekday choices for monthly/yearly relative patterns */
+const RELATIVE_DAY_OPTIONS = [
+  { value: 'MO', label: 'Monday' },
+  { value: 'TU', label: 'Tuesday' },
+  { value: 'WE', label: 'Wednesday' },
+  { value: 'TH', label: 'Thursday' },
+  { value: 'FR', label: 'Friday' },
+  { value: 'SA', label: 'Saturday' },
+  { value: 'SU', label: 'Sunday' },
+  { value: 'MO,TU,WE,TH,FR', label: 'Weekday' },
+  { value: 'SA,SU', label: 'Weekend day' },
+  { value: 'MO,TU,WE,TH,FR,SA,SU', label: 'Day' },
+];
+
+const MONTH_NAMES = [
+  'January', 'February', 'March', 'April', 'May', 'June',
+  'July', 'August', 'September', 'October', 'November', 'December',
+];
+
+/** Build an RRULE string from the Outlook-style form state */
+function buildRrule(
+  freq: RecurrenceFreq,
+  opts: {
+    dailyMode: DailyMode;
+    dailyInterval: number;
+    weeklyInterval: number;
+    weeklyDays: string[];         // ['mon','tue',...]
+    monthlyMode: MonthlyMode;
+    monthlyInterval: number;
+    monthlyDayOfMonth: number;
+    monthlyOrdinal: string;       // '1','-1', etc.
+    monthlyWeekday: string;       // 'MO', 'MO,TU,...'
+    yearlyMode: YearlyMode;
+    yearlyMonth: number;          // 1-12
+    yearlyDayOfMonth: number;
+    yearlyOrdinal: string;
+    yearlyWeekday: string;
+  },
+): { rrule: string | undefined; weekdays: string[] } {
+  switch (freq) {
+    case 'daily': {
+      if (opts.dailyMode === 'weekdays') {
+        // Every weekday → simple weekdays array (no RRULE needed)
+        return { rrule: undefined, weekdays: ['mon', 'tue', 'wed', 'thu', 'fri'] };
+      }
+      if (opts.dailyInterval === 1) {
+        // Every day → all 7 weekdays
+        return { rrule: undefined, weekdays: ['sun', 'mon', 'tue', 'wed', 'thu', 'fri', 'sat'] };
+      }
+      return { rrule: `FREQ=DAILY;INTERVAL=${opts.dailyInterval}`, weekdays: [] };
+    }
+    case 'weekly': {
+      const byDay = opts.weeklyDays.map(d => WEEKDAY_TO_BYDAY[d]).filter(Boolean);
+      if (opts.weeklyInterval === 1 && byDay.length > 0) {
+        // Simple weekly → weekdays array
+        return { rrule: undefined, weekdays: opts.weeklyDays };
+      }
+      const parts = ['FREQ=WEEKLY'];
+      if (opts.weeklyInterval > 1) parts.push(`INTERVAL=${opts.weeklyInterval}`);
+      if (byDay.length > 0) parts.push(`BYDAY=${byDay.join(',')}`);
+      return { rrule: parts.join(';'), weekdays: opts.weeklyDays };
+    }
+    case 'monthly': {
+      const parts = ['FREQ=MONTHLY'];
+      if (opts.monthlyInterval > 1) parts.push(`INTERVAL=${opts.monthlyInterval}`);
+      if (opts.monthlyMode === 'dayOfMonth') {
+        parts.push(`BYMONTHDAY=${opts.monthlyDayOfMonth}`);
+      } else {
+        // e.g. BYDAY=1MO  or  BYDAY=-1FR
+        const ordStr = opts.monthlyOrdinal;
+        const dayTokens = opts.monthlyWeekday.split(',');
+        // For multi-day tokens (Weekday, Weekend, Day), use BYDAY with BYSETPOS
+        if (dayTokens.length > 1) {
+          parts.push(`BYDAY=${dayTokens.join(',')}`);
+          parts.push(`BYSETPOS=${ordStr}`);
+        } else {
+          parts.push(`BYDAY=${ordStr}${dayTokens[0]}`);
+        }
+      }
+      return { rrule: parts.join(';'), weekdays: [] };
+    }
+    case 'yearly': {
+      const parts = ['FREQ=YEARLY', `BYMONTH=${opts.yearlyMonth}`];
+      if (opts.yearlyMode === 'exact') {
+        parts.push(`BYMONTHDAY=${opts.yearlyDayOfMonth}`);
+      } else {
+        const ordStr = opts.yearlyOrdinal;
+        const dayTokens = opts.yearlyWeekday.split(',');
+        if (dayTokens.length > 1) {
+          parts.push(`BYDAY=${dayTokens.join(',')}`);
+          parts.push(`BYSETPOS=${ordStr}`);
+        } else {
+          parts.push(`BYDAY=${ordStr}${dayTokens[0]}`);
+        }
+      }
+      return { rrule: parts.join(';'), weekdays: [] };
+    }
+  }
+}
+
+/** Parse an RRULE string into Outlook-style form state (best-effort) */
+function parseRruleToForm(rrule: string): {
+  freq: RecurrenceFreq;
+  dailyMode: DailyMode; dailyInterval: number;
+  weeklyInterval: number; weeklyDays: string[];
+  monthlyMode: MonthlyMode; monthlyInterval: number; monthlyDayOfMonth: number;
+  monthlyOrdinal: string; monthlyWeekday: string;
+  yearlyMode: YearlyMode; yearlyMonth: number; yearlyDayOfMonth: number;
+  yearlyOrdinal: string; yearlyWeekday: string;
+} | null {
+  const parts = new Map<string, string>();
+  for (const seg of rrule.split(';')) {
+    const [k, v] = seg.split('=');
+    if (k && v) parts.set(k, v);
+  }
+
+  const freqStr = parts.get('FREQ')?.toUpperCase();
+  const interval = Number(parts.get('INTERVAL')) || 1;
+  const byDay = parts.get('BYDAY') || '';
+  const byMonthDay = Number(parts.get('BYMONTHDAY')) || 1;
+  const byMonth = Number(parts.get('BYMONTH')) || 1;
+  const bySetPos = parts.get('BYSETPOS') || '';
+
+  const defaults = {
+    dailyMode: 'interval' as DailyMode, dailyInterval: 1,
+    weeklyInterval: 1, weeklyDays: ['mon', 'tue', 'wed', 'thu', 'fri'] as string[],
+    monthlyMode: 'dayOfMonth' as MonthlyMode, monthlyInterval: 1, monthlyDayOfMonth: 1,
+    monthlyOrdinal: '1', monthlyWeekday: 'MO',
+    yearlyMode: 'exact' as YearlyMode, yearlyMonth: 1, yearlyDayOfMonth: 1,
+    yearlyOrdinal: '1', yearlyWeekday: 'MO',
+  };
+
+  switch (freqStr) {
+    case 'DAILY':
+      return { ...defaults, freq: 'daily', dailyInterval: interval };
+
+    case 'WEEKLY': {
+      const days = byDay ? byDay.split(',').map(d => BYDAY_TO_WEEKDAY[d.trim()]).filter(Boolean) : [];
+      return { ...defaults, freq: 'weekly', weeklyInterval: interval, weeklyDays: days.length ? days : defaults.weeklyDays };
+    }
+
+    case 'MONTHLY': {
+      if (byMonthDay && !byDay) {
+        return { ...defaults, freq: 'monthly', monthlyMode: 'dayOfMonth', monthlyInterval: interval, monthlyDayOfMonth: byMonthDay };
+      }
+      // Parse BYDAY like "1MO" or "-1FR" or BYDAY=MO,TU + BYSETPOS=1
+      let ordinal = '1';
+      let weekday = 'MO';
+      if (bySetPos) {
+        ordinal = bySetPos;
+        weekday = byDay;
+      } else if (byDay) {
+        const m = byDay.match(/^(-?\d)(.+)$/);
+        if (m) {
+          ordinal = m[1];
+          weekday = m[2];
+        } else {
+          weekday = byDay;
+        }
+      }
+      return { ...defaults, freq: 'monthly', monthlyMode: 'weekdayOfMonth', monthlyInterval: interval, monthlyOrdinal: ordinal, monthlyWeekday: weekday };
+    }
+
+    case 'YEARLY': {
+      if (byMonthDay && !byDay) {
+        return { ...defaults, freq: 'yearly', yearlyMode: 'exact', yearlyMonth: byMonth, yearlyDayOfMonth: byMonthDay };
+      }
+      let ordinal = '1';
+      let weekday = 'MO';
+      if (bySetPos) {
+        ordinal = bySetPos;
+        weekday = byDay;
+      } else if (byDay) {
+        const m = byDay.match(/^(-?\d)(.+)$/);
+        if (m) {
+          ordinal = m[1];
+          weekday = m[2];
+        } else {
+          weekday = byDay;
+        }
+      }
+      return { ...defaults, freq: 'yearly', yearlyMode: 'relative', yearlyMonth: byMonth, yearlyOrdinal: ordinal, yearlyWeekday: weekday };
+    }
+
+    default:
+      return null;
+  }
+}
+
+const DEFAULT_BLOCKS: AvailabilityBlock[] = [
+  { start: '08:00', end: '12:00', duration: 30 },
+  { start: '13:00', end: '17:00', duration: 30 },
+];
+
+// ==================== Helpers ====================
+
+function getProviderName(schedule: Schedule): string {
+  const firstActor = schedule.actor?.[0];
+  return firstActor?.display || firstActor?.reference?.split('/').pop() || 'Provider';
+}
+
+function getSystemName(schedule: Schedule): string {
+  const ext = schedule.extension?.find(
+    (e: { url: string; valueString?: string }) =>
+      e.url === 'https://fhirtogether.org/fhir/StructureDefinition/system-name'
+  );
+  return ext?.valueString || 'Local';
+}
+
+/** Format a date as YYYY-MM-DD */
+function toDateString(date: Date): string {
+  const y = date.getFullYear();
+  const m = String(date.getMonth() + 1).padStart(2, '0');
+  const d = String(date.getDate()).padStart(2, '0');
+  return `${y}-${m}-${d}`;
+}
+
+/** Count matching weekdays between two dates */
+function countWeekdaysBetween(startStr: string, endStr: string, weekdays: string[]): number {
+  const start = new Date(startStr + 'T00:00:00');
+  const end = new Date(endStr + 'T00:00:00');
+  const dayNums = weekdays.map(d => DAY_NUMBERS[d]);
+  let count = 0;
+  const d = new Date(start);
+  while (d <= end) {
+    if (dayNums.includes(d.getDay())) count++;
+    d.setDate(d.getDate() + 1);
+  }
+  return count;
+}
+
+/** Get sample dates (first 5 + last 2) matching weekdays */
+function getSampleDates(startStr: string, endStr: string, weekdays: string[], max = 7): string[] {
+  const start = new Date(startStr + 'T00:00:00');
+  const end = new Date(endStr + 'T00:00:00');
+  const dayNums = weekdays.map(d => DAY_NUMBERS[d]);
+  const matches: string[] = [];
+  const d = new Date(start);
+  while (d <= end) {
+    if (dayNums.includes(d.getDay())) {
+      matches.push(toDateString(d));
+    }
+    d.setDate(d.getDate() + 1);
+  }
+  if (matches.length <= max) return matches;
+  return [...matches.slice(0, 5), '…', ...matches.slice(-2)];
+}
+
+/** Count slots per day from blocks */
+function slotsPerDay(blocks: AvailabilityBlock[]): number {
+  let total = 0;
+  for (const block of blocks) {
+    const [sh, sm] = block.start.split(':').map(Number);
+    const [eh, em] = block.end.split(':').map(Number);
+    const blockMinutes = (eh * 60 + em) - (sh * 60 + sm);
+    if (blockMinutes > 0 && block.duration > 0) {
+      total += Math.floor(blockMinutes / block.duration);
+    }
+  }
+  return total;
+}
+
+// ==================== YAML Helpers ====================
+
+/** Serialize form state to the Schedule YAML format */
+function templateToYaml(t: AvailabilityTemplate): string {
+  const lines: string[] = [];
+  lines.push(`startDate: "${t.startDate}"`);
+  lines.push(`endDate:   "${t.endDate}"`);
+
+  if (t.rrule) {
+    lines.push(`rrule: "${t.rrule}"`);
+  } else if (t.weekdays?.length) {
+    lines.push(`weekdays:  [${t.weekdays.join(', ')}]`);
+  }
+
+  if (t.exdates?.length) {
+    lines.push(`exdates: [${t.exdates.join(', ')}]`);
+  }
+
+  if (t.appointmentTypes?.length) {
+    lines.push('');
+    lines.push('appointmentTypes:');
+    for (const at of t.appointmentTypes) {
+      lines.push(`  - code: ${at.code}`);
+      if (at.description) lines.push(`    description: "${at.description}"`);
+      if (at.duration) lines.push(`    duration: ${at.duration}`);
+    }
+  }
+
+  lines.push('');
+  lines.push('blocks:');
+  for (const b of t.blocks) {
+    lines.push(`  - start: "${b.start}"`);
+    lines.push(`    end:   "${b.end}"`);
+    lines.push(`    duration: ${b.duration}`);
+    if (b.types?.length) lines.push(`    types: [${b.types.join(', ')}]`);
+    if (b.overbook !== undefined && b.overbook > 0) lines.push(`    overbook: ${b.overbook}`);
+  }
+
+  return lines.join('\n') + '\n';
+}
+
+/** Parse Schedule YAML back into an AvailabilityTemplate (best-effort) */
+function yamlToTemplate(yaml: string): AvailabilityTemplate | null {
+  try {
+    const t: AvailabilityTemplate = { startDate: '', endDate: '', weekdays: [], blocks: [] };
+
+    // Simple key-value extraction
+    const val = (key: string): string | undefined => {
+      const re = new RegExp(`^${key}:\\s*"?([^"\\n]+)"?`, 'm');
+      const m = yaml.match(re);
+      return m ? m[1].trim() : undefined;
+    };
+
+    const arr = (key: string): string[] => {
+      const re = new RegExp(`^${key}:\\s*\\[([^\\]]+)\\]`, 'm');
+      const m = yaml.match(re);
+      return m ? m[1].split(',').map(s => s.trim().replace(/^"|"$/g, '')) : [];
+    };
+
+    t.startDate = val('startDate') || '';
+    t.endDate = val('endDate') || '';
+    t.rrule = val('rrule');
+    t.weekdays = arr('weekdays');
+    t.exdates = arr('exdates');
+    if (t.exdates.length === 0) t.exdates = undefined;
+
+    // Parse blocks
+    const blockMatches = [...yaml.matchAll(/- start:\s*"?(\d{2}:\d{2})"?/g)];
+    for (const bm of blockMatches) {
+      const idx = bm.index!;
+      // Grab the text from this "- start:" to the next "- start:" or end
+      const nextBlock = yaml.indexOf('- start:', idx + 1);
+      const chunk = yaml.slice(idx, nextBlock > -1 ? nextBlock : undefined);
+
+      const end = chunk.match(/end:\s*"?(\d{2}:\d{2})"?/)?.[1] || '';
+      const dur = chunk.match(/duration:\s*(\d+)/)?.[1];
+      const types = chunk.match(/types:\s*\[([^\]]+)\]/)?.[1]?.split(',').map(s => s.trim());
+      const overbook = chunk.match(/overbook:\s*(\d+)/)?.[1];
+
+      t.blocks.push({
+        start: bm[1],
+        end,
+        duration: dur ? Number(dur) : 30,
+        types: types?.length ? types : undefined,
+        overbook: overbook !== undefined ? Number(overbook) : undefined,
+      });
+    }
+
+    // Parse appointment types
+    const aptSection = yaml.match(/appointmentTypes:\n([\s\S]*?)(?=\nblocks:|\n\S|\Z)/);
+    if (aptSection) {
+      const aptTypes: AppointmentTypeDefinition[] = [];
+      const codeMatches = [...aptSection[1].matchAll(/- code:\s*(.+)/g)];
+      for (const cm of codeMatches) {
+        const cIdx = cm.index!;
+        const nextCode = aptSection[1].indexOf('- code:', cIdx + 1);
+        const chunk = aptSection[1].slice(cIdx, nextCode > -1 ? nextCode : undefined);
+
+        const desc = chunk.match(/description:\s*"?([^"\n]+)"?/)?.[1]?.trim();
+        const dur = chunk.match(/duration:\s*(\d+)/)?.[1];
+
+        aptTypes.push({
+          code: cm[1].trim(),
+          description: desc,
+          duration: dur ? Number(dur) : undefined,
+        });
+      }
+      if (aptTypes.length) t.appointmentTypes = aptTypes;
+    }
+
+    if (!t.startDate || !t.endDate || t.blocks.length === 0) return null;
+    return t;
+  } catch {
+    return null;
+  }
+}
+
+// ==================== Component ====================
+
+export function ScheduleSetup({ fhirBaseUrl, initialScheduleId, onGenerate }: ScheduleSetupProps) {
+  // Providers
+  const [providers, setProviders] = useState<Schedule[]>([]);
+  const [selectedProvider, setSelectedProvider] = useState<Schedule | null>(null);
+  const [providersLoading, setProvidersLoading] = useState(true);
+
+  // Template fields
+  const today = toDateString(new Date());
+  const sixMonthsLater = useMemo(() => {
+    const d = new Date();
+    d.setMonth(d.getMonth() + 6);
+    return toDateString(d);
+  }, []);
+
+  const [startDate, setStartDate] = useState(today);
+  const [endDate, setEndDate] = useState(sixMonthsLater);
+
+  // Recurrence builder state (Outlook-style)
+  const [recFreq, setRecFreq] = useState<RecurrenceFreq>('weekly');
+  const [dailyMode, setDailyMode] = useState<DailyMode>('weekdays');
+  const [dailyInterval, setDailyInterval] = useState(1);
+  const [weeklyInterval, setWeeklyInterval] = useState(1);
+  const [selectedWeekdays, setSelectedWeekdays] = useState<string[]>(['mon', 'tue', 'wed', 'thu', 'fri']);
+  const [monthlyMode, setMonthlyMode] = useState<MonthlyMode>('dayOfMonth');
+  const [monthlyInterval, setMonthlyInterval] = useState(1);
+  const [monthlyDayOfMonth, setMonthlyDayOfMonth] = useState(1);
+  const [monthlyOrdinal, setMonthlyOrdinal] = useState('1');
+  const [monthlyWeekday, setMonthlyWeekday] = useState('MO');
+  const [yearlyMode, setYearlyMode] = useState<YearlyMode>('exact');
+  const [yearlyMonth, setYearlyMonth] = useState(1);
+  const [yearlyDayOfMonth, setYearlyDayOfMonth] = useState(1);
+  const [yearlyOrdinal, setYearlyOrdinal] = useState('1');
+  const [yearlyWeekday, setYearlyWeekday] = useState('MO');
+
+  const [exdates, setExdates] = useState<string[]>([]);
+  const [blocks, setBlocks] = useState<AvailabilityBlock[]>(() => DEFAULT_BLOCKS.map(b => ({ ...b })));
+  const [appointmentTypes, setAppointmentTypes] = useState<AppointmentTypeDefinition[]>([]);
+  const [showTypes, setShowTypes] = useState(false);
+  const [showYaml, setShowYaml] = useState(false);
+  const [yamlText, setYamlText] = useState('');
+  const [yamlError, setYamlError] = useState<string | null>(null);
+  const [mode, setMode] = useState<'replace' | 'incremental'>('replace');
+
+  // Status
+  const [generating, setGenerating] = useState(false);
+  const [result, setResult] = useState<GenerateSlotsResult | null>(null);
+  const [error, setError] = useState<string | null>(null);
+
+  const client = useMemo(() => createFhirClient({ baseUrl: fhirBaseUrl }), [fhirBaseUrl]);
+
+  // Fetch providers
+  useEffect(() => {
+    async function fetchProviders() {
+      setProvidersLoading(true);
+      try {
+        const res = await fetch(`${fhirBaseUrl}/Schedule?active=true`, {
+          headers: { 'Content-Type': 'application/json' },
+        });
+        if (!res.ok) throw new Error(`Failed to fetch providers: ${res.statusText}`);
+        const bundle: Bundle<Schedule> = await res.json();
+        const list = bundle.entry?.map(e => e.resource) || [];
+        setProviders(list);
+        const match = initialScheduleId ? list.find(p => p.id === initialScheduleId) : null;
+        if (match) setSelectedProvider(match);
+        else if (list.length > 0) setSelectedProvider(list[0]);
+      } catch (err) {
+        setError(err instanceof Error ? err.message : 'Failed to load providers');
+      } finally {
+        setProvidersLoading(false);
+      }
+    }
+    fetchProviders();
+  }, [fhirBaseUrl, initialScheduleId]);
+
+  // Preview calculations
+  const preview = useMemo(() => {
+    if (!startDate || !endDate || selectedWeekdays.length === 0 || blocks.length === 0) {
+      return null;
+    }
+    const dayCount = countWeekdaysBetween(startDate, endDate, selectedWeekdays);
+    const perDay = slotsPerDay(blocks);
+    const totalSlots = dayCount * perDay;
+    const sampleDates = getSampleDates(startDate, endDate, selectedWeekdays);
+    return { dayCount, perDay, totalSlots, sampleDates };
+  }, [startDate, endDate, selectedWeekdays, blocks]);
+
+  // Weekday toggle
+  const toggleWeekday = useCallback((day: string) => {
+    setSelectedWeekdays(prev =>
+      prev.includes(day) ? prev.filter(d => d !== day) : [...prev, day]
+    );
+  }, []);
+
+  // Build the current template from form state (used for YAML export + generate)
+  const currentTemplate = useMemo((): AvailabilityTemplate => {
+    const rec = buildRrule(recFreq, {
+      dailyMode, dailyInterval,
+      weeklyInterval, weeklyDays: selectedWeekdays,
+      monthlyMode, monthlyInterval, monthlyDayOfMonth, monthlyOrdinal, monthlyWeekday,
+      yearlyMode, yearlyMonth, yearlyDayOfMonth, yearlyOrdinal, yearlyWeekday,
+    });
+
+    const t: AvailabilityTemplate = {
+      startDate,
+      endDate,
+      weekdays: rec.weekdays.length > 0 ? rec.weekdays : selectedWeekdays,
+      blocks: blocks.map(b => ({
+        ...b,
+        duration: Number(b.duration),
+        overbook: b.overbook !== undefined ? Number(b.overbook) : undefined,
+      })),
+    };
+    if (rec.rrule) {
+      t.rrule = rec.rrule;
+    }
+    if (exdates.length > 0) {
+      t.exdates = exdates;
+    }
+    if (appointmentTypes.length > 0) {
+      const filtered = appointmentTypes.filter(at => at.code.trim());
+      if (filtered.length) t.appointmentTypes = filtered;
+    }
+    return t;
+  }, [startDate, endDate, selectedWeekdays, recFreq, dailyMode, dailyInterval, weeklyInterval,
+      monthlyMode, monthlyInterval, monthlyDayOfMonth, monthlyOrdinal, monthlyWeekday,
+      yearlyMode, yearlyMonth, yearlyDayOfMonth, yearlyOrdinal, yearlyWeekday,
+      exdates, blocks, appointmentTypes]);
+
+  // Sync form → YAML when the YAML panel is open
+  useEffect(() => {
+    if (showYaml) {
+      setYamlText(templateToYaml(currentTemplate));
+      setYamlError(null);
+    }
+  }, [showYaml, currentTemplate]);
+
+  // Apply YAML edits → form state
+  const applyYaml = useCallback(() => {
+    const parsed = yamlToTemplate(yamlText);
+    if (!parsed) {
+      setYamlError('Invalid YAML — could not parse. Check format and try again.');
+      return;
+    }
+    setYamlError(null);
+    setStartDate(parsed.startDate);
+    setEndDate(parsed.endDate);
+
+    if (parsed.rrule) {
+      const formState = parseRruleToForm(parsed.rrule);
+      if (formState) {
+        setRecFreq(formState.freq);
+        setDailyMode(formState.dailyMode);
+        setDailyInterval(formState.dailyInterval);
+        setWeeklyInterval(formState.weeklyInterval);
+        setSelectedWeekdays(formState.weeklyDays);
+        setMonthlyMode(formState.monthlyMode);
+        setMonthlyInterval(formState.monthlyInterval);
+        setMonthlyDayOfMonth(formState.monthlyDayOfMonth);
+        setMonthlyOrdinal(formState.monthlyOrdinal);
+        setMonthlyWeekday(formState.monthlyWeekday);
+        setYearlyMode(formState.yearlyMode);
+        setYearlyMonth(formState.yearlyMonth);
+        setYearlyDayOfMonth(formState.yearlyDayOfMonth);
+        setYearlyOrdinal(formState.yearlyOrdinal);
+        setYearlyWeekday(formState.yearlyWeekday);
+      }
+    } else {
+      setRecFreq('weekly');
+      setWeeklyInterval(1);
+      setSelectedWeekdays(parsed.weekdays || []);
+    }
+
+    setExdates(parsed.exdates || []);
+    setBlocks(parsed.blocks);
+    setAppointmentTypes(parsed.appointmentTypes || []);
+    setShowTypes(!!(parsed.appointmentTypes?.length));
+  }, [yamlText]);
+
+  // Exdate management
+  const addExdate = useCallback(() => {
+    setExdates(prev => [...prev, '']);
+  }, []);
+
+  const updateExdate = useCallback((index: number, value: string) => {
+    setExdates(prev => {
+      const updated = [...prev];
+      updated[index] = value;
+      return updated;
+    });
+  }, []);
+
+  const removeExdate = useCallback((index: number) => {
+    setExdates(prev => prev.filter((_, i) => i !== index));
+  }, []);
+
+  // Block management
+  const updateBlock = useCallback((index: number, field: keyof AvailabilityBlock, value: string | number) => {
+    setBlocks(prev => {
+      const updated = [...prev];
+      updated[index] = { ...updated[index], [field]: value };
+      return updated;
+    });
+  }, []);
+
+  const addBlock = useCallback(() => {
+    setBlocks(prev => [...prev, { start: '09:00', end: '10:00', duration: 30 }]);
+  }, []);
+
+  const removeBlock = useCallback((index: number) => {
+    setBlocks(prev => prev.filter((_, i) => i !== index));
+  }, []);
+
+  // Appointment type management
+  const updateType = useCallback((index: number, field: keyof AppointmentTypeDefinition, value: string | number) => {
+    setAppointmentTypes(prev => {
+      const updated = [...prev];
+      updated[index] = { ...updated[index], [field]: value };
+      return updated;
+    });
+  }, []);
+
+  const addType = useCallback(() => {
+    setAppointmentTypes(prev => [...prev, { code: '', description: '' }]);
+  }, []);
+
+  const removeType = useCallback((index: number) => {
+    setAppointmentTypes(prev => prev.filter((_, i) => i !== index));
+    // Also remove references from blocks
+    const removedCode = appointmentTypes[index]?.code;
+    if (removedCode) {
+      setBlocks(prev => prev.map(b =>
+        b.types ? { ...b, types: b.types.filter(t => t !== removedCode) } : b
+      ));
+    }
+  }, [appointmentTypes]);
+
+  const toggleBlockType = useCallback((blockIndex: number, typeCode: string) => {
+    setBlocks(prev => {
+      const updated = [...prev];
+      const block = { ...updated[blockIndex] };
+      const types = block.types ? [...block.types] : [];
+      if (types.includes(typeCode)) {
+        block.types = types.filter(t => t !== typeCode);
+      } else {
+        block.types = [...types, typeCode];
+      }
+      if (block.types.length === 0) block.types = undefined;
+      updated[blockIndex] = block;
+      return updated;
+    });
+  }, []);
+
+  // Generate slots
+  const handleGenerate = useCallback(async () => {
+    if (!selectedProvider?.id) return;
+
+    setGenerating(true);
+    setError(null);
+    setResult(null);
+
+    try {
+      const res = await client.generateSlots(selectedProvider.id, currentTemplate, mode);
+      setResult(res);
+      onGenerate?.(res);
+    } catch (err) {
+      setError(err instanceof Error ? err.message : 'Failed to generate slots');
+    } finally {
+      setGenerating(false);
+    }
+  }, [selectedProvider, currentTemplate, mode, client, onGenerate]);
+
+  const canGenerate = selectedProvider && startDate && endDate && selectedWeekdays.length > 0 && blocks.length > 0 && !generating;
+
+  // Loading state
+  if (providersLoading) {
+    return (
+      <div className="fs-scheduler-widget fs-schedule-setup">
+        <div className="fs-loading">
+          <div className="fs-loading-spinner">
+            <svg className="fs-spinner" viewBox="0 0 50 50" aria-label="Loading providers">
+              <circle className="fs-spinner-track" cx="25" cy="25" r="20" fill="none" strokeWidth="4" />
+              <circle className="fs-spinner-head" cx="25" cy="25" r="20" fill="none" strokeWidth="4" strokeDasharray="80, 200" strokeLinecap="round" />
+            </svg>
+            <span className="fs-loading-text">Loading providers...</span>
+          </div>
+        </div>
+      </div>
+    );
+  }
+
+  return (
+    <div className="fs-scheduler-widget fs-schedule-setup">
+      <header className="fs-schedule-setup-header">
+        <h2 className="fs-section-title">Schedule Setup</h2>
+        <p className="fs-schedule-setup-subtitle">
+          Define recurring availability to generate bookable time slots.
+        </p>
+      </header>
+
+      {/* Provider selector */}
+      <section className="fs-schedule-setup-section" aria-label="Select provider">
+        <label htmlFor="schedule-provider" className="fs-schedule-setup-label">Provider</label>
+        <select
+          id="schedule-provider"
+          className="fs-apptlist-select"
+          value={selectedProvider?.id || ''}
+          onChange={e => {
+            const provider = providers.find(p => p.id === e.target.value);
+            setSelectedProvider(provider || null);
+          }}
+          aria-label="Select a provider to configure schedule"
+        >
+          {(() => {
+            const groups = new Map<string, Schedule[]>();
+            for (const p of providers) {
+              const sys = getSystemName(p);
+              const list = groups.get(sys) || [];
+              list.push(p);
+              groups.set(sys, list);
+            }
+            if (groups.size <= 1) {
+              return providers.map(p => (
+                <option key={p.id} value={p.id}>{getProviderName(p)}</option>
+              ));
+            }
+            return Array.from(groups.entries()).map(([systemName, groupProviders]) => (
+              <optgroup key={systemName} label={systemName}>
+                {groupProviders.map(p => (
+                  <option key={p.id} value={p.id}>{getProviderName(p)}</option>
+                ))}
+              </optgroup>
+            ));
+          })()}
+        </select>
+      </section>
+
+      {/* Date range */}
+      <section className="fs-schedule-setup-section" aria-label="Date range">
+        <h3 className="fs-schedule-setup-label">Date Range</h3>
+        <div className="fs-schedule-setup-row">
+          <div className="fs-schedule-setup-field">
+            <label htmlFor="schedule-start-date">Start</label>
+            <input
+              id="schedule-start-date"
+              type="date"
+              className="fs-schedule-setup-input"
+              value={startDate}
+              onChange={e => setStartDate(e.target.value)}
+            />
+          </div>
+          <div className="fs-schedule-setup-field">
+            <label htmlFor="schedule-end-date">End</label>
+            <input
+              id="schedule-end-date"
+              type="date"
+              className="fs-schedule-setup-input"
+              value={endDate}
+              onChange={e => setEndDate(e.target.value)}
+            />
+          </div>
+        </div>
+      </section>
+
+      {/* Recurrence pattern (Outlook-style) */}
+      <section className="fs-schedule-setup-section" aria-label="Recurrence pattern">
+        <h3 className="fs-schedule-setup-label">Recurrence</h3>
+
+        {/* Frequency tabs */}
+        <div className="fs-recurrence-tabs" role="tablist" aria-label="Recurrence frequency">
+          {(['daily', 'weekly', 'monthly', 'yearly'] as RecurrenceFreq[]).map(f => (
+            <button
+              key={f}
+              type="button"
+              role="tab"
+              aria-selected={recFreq === f}
+              className={`fs-recurrence-tab ${recFreq === f ? 'fs-recurrence-tab-active' : ''}`}
+              onClick={() => setRecFreq(f)}
+            >
+              {f.charAt(0).toUpperCase() + f.slice(1)}
+            </button>
+          ))}
+        </div>
+
+        {/* Daily options */}
+        {recFreq === 'daily' && (
+          <div className="fs-recurrence-panel" role="tabpanel" aria-label="Daily options">
+            <label className="fs-recurrence-radio-row">
+              <input
+                type="radio"
+                name="daily-mode"
+                checked={dailyMode === 'interval'}
+                onChange={() => setDailyMode('interval')}
+              />
+              Every
+              <input
+                type="number"
+                className="fs-recurrence-num"
+                min={1}
+                max={365}
+                value={dailyInterval}
+                onChange={e => setDailyInterval(Math.max(1, Number(e.target.value)))}
+                disabled={dailyMode !== 'interval'}
+                aria-label="Day interval"
+              />
+              day(s)
+            </label>
+            <label className="fs-recurrence-radio-row">
+              <input
+                type="radio"
+                name="daily-mode"
+                checked={dailyMode === 'weekdays'}
+                onChange={() => setDailyMode('weekdays')}
+              />
+              Every weekday (Mon–Fri)
+            </label>
+          </div>
+        )}
+
+        {/* Weekly options */}
+        {recFreq === 'weekly' && (
+          <div className="fs-recurrence-panel" role="tabpanel" aria-label="Weekly options">
+            <div className="fs-recurrence-inline-row">
+              <span>Recur every</span>
+              <input
+                type="number"
+                className="fs-recurrence-num"
+                min={1}
+                max={52}
+                value={weeklyInterval}
+                onChange={e => setWeeklyInterval(Math.max(1, Number(e.target.value)))}
+                aria-label="Week interval"
+              />
+              <span>week(s) on:</span>
+            </div>
+            <div className="fs-weekday-picker" role="group" aria-label="Weekday selection">
+              {WEEKDAYS.map(day => (
+                <button
+                  key={day}
+                  type="button"
+                  className={`fs-weekday-btn ${selectedWeekdays.includes(day) ? 'fs-weekday-btn-active' : ''}`}
+                  onClick={() => toggleWeekday(day)}
+                  aria-pressed={selectedWeekdays.includes(day)}
+                  aria-label={day}
+                >
+                  {WEEKDAY_LABELS[day]}
+                </button>
+              ))}
+            </div>
+          </div>
+        )}
+
+        {/* Monthly options */}
+        {recFreq === 'monthly' && (
+          <div className="fs-recurrence-panel" role="tabpanel" aria-label="Monthly options">
+            <label className="fs-recurrence-radio-row">
+              <input
+                type="radio"
+                name="monthly-mode"
+                checked={monthlyMode === 'dayOfMonth'}
+                onChange={() => setMonthlyMode('dayOfMonth')}
+              />
+              Day
+              <input
+                type="number"
+                className="fs-recurrence-num"
+                min={1}
+                max={31}
+                value={monthlyDayOfMonth}
+                onChange={e => setMonthlyDayOfMonth(Math.max(1, Math.min(31, Number(e.target.value))))}
+                disabled={monthlyMode !== 'dayOfMonth'}
+                aria-label="Day of month"
+              />
+              of every
+              <input
+                type="number"
+                className="fs-recurrence-num"
+                min={1}
+                max={12}
+                value={monthlyInterval}
+                onChange={e => setMonthlyInterval(Math.max(1, Number(e.target.value)))}
+                disabled={monthlyMode !== 'dayOfMonth'}
+                aria-label="Month interval"
+              />
+              month(s)
+            </label>
+            <label className="fs-recurrence-radio-row">
+              <input
+                type="radio"
+                name="monthly-mode"
+                checked={monthlyMode === 'weekdayOfMonth'}
+                onChange={() => setMonthlyMode('weekdayOfMonth')}
+              />
+              The
+              <select
+                className="fs-recurrence-select"
+                value={monthlyOrdinal}
+                onChange={e => setMonthlyOrdinal(e.target.value)}
+                disabled={monthlyMode !== 'weekdayOfMonth'}
+                aria-label="Ordinal position"
+              >
+                {ORDINALS.map(o => (
+                  <option key={o.value} value={o.value}>{o.label}</option>
+                ))}
+              </select>
+              <select
+                className="fs-recurrence-select"
+                value={monthlyWeekday}
+                onChange={e => setMonthlyWeekday(e.target.value)}
+                disabled={monthlyMode !== 'weekdayOfMonth'}
+                aria-label="Day of week"
+              >
+                {RELATIVE_DAY_OPTIONS.map(d => (
+                  <option key={d.value} value={d.value}>{d.label}</option>
+                ))}
+              </select>
+              of every
+              <input
+                type="number"
+                className="fs-recurrence-num"
+                min={1}
+                max={12}
+                value={monthlyInterval}
+                onChange={e => setMonthlyInterval(Math.max(1, Number(e.target.value)))}
+                disabled={monthlyMode !== 'weekdayOfMonth'}
+                aria-label="Month interval"
+              />
+              month(s)
+            </label>
+          </div>
+        )}
+
+        {/* Yearly options */}
+        {recFreq === 'yearly' && (
+          <div className="fs-recurrence-panel" role="tabpanel" aria-label="Yearly options">
+            <label className="fs-recurrence-radio-row">
+              <input
+                type="radio"
+                name="yearly-mode"
+                checked={yearlyMode === 'exact'}
+                onChange={() => setYearlyMode('exact')}
+              />
+              Every
+              <select
+                className="fs-recurrence-select"
+                value={yearlyMonth}
+                onChange={e => setYearlyMonth(Number(e.target.value))}
+                disabled={yearlyMode !== 'exact'}
+                aria-label="Month"
+              >
+                {MONTH_NAMES.map((m, i) => (
+                  <option key={i} value={i + 1}>{m}</option>
+                ))}
+              </select>
+              <input
+                type="number"
+                className="fs-recurrence-num"
+                min={1}
+                max={31}
+                value={yearlyDayOfMonth}
+                onChange={e => setYearlyDayOfMonth(Math.max(1, Math.min(31, Number(e.target.value))))}
+                disabled={yearlyMode !== 'exact'}
+                aria-label="Day of month"
+              />
+            </label>
+            <label className="fs-recurrence-radio-row">
+              <input
+                type="radio"
+                name="yearly-mode"
+                checked={yearlyMode === 'relative'}
+                onChange={() => setYearlyMode('relative')}
+              />
+              The
+              <select
+                className="fs-recurrence-select"
+                value={yearlyOrdinal}
+                onChange={e => setYearlyOrdinal(e.target.value)}
+                disabled={yearlyMode !== 'relative'}
+                aria-label="Ordinal position"
+              >
+                {ORDINALS.map(o => (
+                  <option key={o.value} value={o.value}>{o.label}</option>
+                ))}
+              </select>
+              <select
+                className="fs-recurrence-select"
+                value={yearlyWeekday}
+                onChange={e => setYearlyWeekday(e.target.value)}
+                disabled={yearlyMode !== 'relative'}
+                aria-label="Day of week"
+              >
+                {RELATIVE_DAY_OPTIONS.map(d => (
+                  <option key={d.value} value={d.value}>{d.label}</option>
+                ))}
+              </select>
+              of
+              <select
+                className="fs-recurrence-select"
+                value={yearlyMonth}
+                onChange={e => setYearlyMonth(Number(e.target.value))}
+                disabled={yearlyMode !== 'relative'}
+                aria-label="Month"
+              >
+                {MONTH_NAMES.map((m, i) => (
+                  <option key={i} value={i + 1}>{m}</option>
+                ))}
+              </select>
+            </label>
+          </div>
+        )}
+
+        {/* Generated RRULE display */}
+        {(() => {
+          const rec = buildRrule(recFreq, {
+            dailyMode, dailyInterval, weeklyInterval, weeklyDays: selectedWeekdays,
+            monthlyMode, monthlyInterval, monthlyDayOfMonth, monthlyOrdinal, monthlyWeekday,
+            yearlyMode, yearlyMonth, yearlyDayOfMonth, yearlyOrdinal, yearlyWeekday,
+          });
+          return rec.rrule ? (
+            <div className="fs-rrule-display" aria-label="Generated RRULE">
+              <code>{rec.rrule}</code>
+            </div>
+          ) : null;
+        })()}
+
+        {/* Excluded dates */}
+        <div className="fs-exdates-section">
+          <div className="fs-schedule-setup-label-row">
+            <span className="fs-schedule-setup-sublabel">Excluded dates (holidays, closures)</span>
+            <button
+              type="button"
+              className="fs-secondary-button fs-schedule-setup-preset-btn"
+              onClick={addExdate}
+              aria-label="Add excluded date"
+            >
+              + Add Date
+            </button>
+          </div>
+          {exdates.length > 0 && (
+            <div className="fs-exdate-list">
+              {exdates.map((d, i) => (
+                <div key={i} className="fs-exdate-row">
+                  <input
+                    type="date"
+                    className="fs-schedule-setup-input"
+                    value={d}
+                    onChange={e => updateExdate(i, e.target.value)}
+                    aria-label={`Excluded date ${i + 1}`}
+                  />
+                  <button
+                    type="button"
+                    className="fs-block-remove"
+                    onClick={() => removeExdate(i)}
+                    aria-label={`Remove excluded date ${i + 1}`}
+                  >
+                    ×
+                  </button>
+                </div>
+              ))}
+            </div>
+          )}
+        </div>
+      </section>
+
+      {/* Time blocks */}
+      <section className="fs-schedule-setup-section" aria-label="Time blocks">
+        <h3 className="fs-schedule-setup-label">Time Blocks</h3>
+        <div className="fs-block-list">
+          {blocks.map((block, i) => (
+            <div key={i} className="fs-block-row" aria-label={`Block ${i + 1}`}>
+              <div className="fs-schedule-setup-field">
+                <label htmlFor={`block-start-${i}`}>Start</label>
+                <input
+                  id={`block-start-${i}`}
+                  type="time"
+                  className="fs-schedule-setup-input"
+                  value={block.start}
+                  onChange={e => updateBlock(i, 'start', e.target.value)}
+                />
+              </div>
+              <div className="fs-schedule-setup-field">
+                <label htmlFor={`block-end-${i}`}>End</label>
+                <input
+                  id={`block-end-${i}`}
+                  type="time"
+                  className="fs-schedule-setup-input"
+                  value={block.end}
+                  onChange={e => updateBlock(i, 'end', e.target.value)}
+                />
+              </div>
+              <div className="fs-schedule-setup-field">
+                <label htmlFor={`block-dur-${i}`}>Duration</label>
+                <select
+                  id={`block-dur-${i}`}
+                  className="fs-schedule-setup-input"
+                  value={block.duration}
+                  onChange={e => updateBlock(i, 'duration', Number(e.target.value))}
+                >
+                  {DURATION_OPTIONS.map(d => (
+                    <option key={d} value={d}>{d} min</option>
+                  ))}
+                </select>
+              </div>
+              {/* Per-block type checkboxes */}
+              {showTypes && appointmentTypes.length > 0 && (
+                <div className="fs-schedule-setup-field fs-block-types">
+                  <span className="fs-block-types-label">Types</span>
+                  {appointmentTypes.filter(t => t.code.trim()).map(t => (
+                    <label key={t.code} className="fs-block-type-check">
+                      <input
+                        type="checkbox"
+                        checked={block.types?.includes(t.code) || false}
+                        onChange={() => toggleBlockType(i, t.code)}
+                      />
+                      {t.code}
+                    </label>
+                  ))}
+                </div>
+              )}
+              <button
+                type="button"
+                className="fs-block-remove"
+                onClick={() => removeBlock(i)}
+                aria-label={`Remove block ${i + 1}`}
+                disabled={blocks.length <= 1}
+              >
+                ×
+              </button>
+            </div>
+          ))}
+        </div>
+        <button type="button" className="fs-secondary-button" onClick={addBlock}>
+          + Add Block
+        </button>
+      </section>
+
+      {/* Appointment types (collapsible) */}
+      <section className="fs-schedule-setup-section" aria-label="Appointment types">
+        <button
+          type="button"
+          className="fs-schedule-setup-toggle"
+          onClick={() => setShowTypes(!showTypes)}
+          aria-expanded={showTypes}
+        >
+          <span className={`fs-toggle-arrow ${showTypes ? 'fs-toggle-arrow-open' : ''}`}>▸</span>
+          Appointment Types
+          <span className="fs-schedule-setup-optional">(optional)</span>
+        </button>
+        {showTypes && (
+          <div className="fs-type-list">
+            {appointmentTypes.map((type, i) => (
+              <div key={i} className="fs-type-row" aria-label={`Appointment type ${i + 1}`}>
+                <div className="fs-schedule-setup-field">
+                  <label htmlFor={`type-code-${i}`}>Code</label>
+                  <input
+                    id={`type-code-${i}`}
+                    type="text"
+                    className="fs-schedule-setup-input"
+                    placeholder="OV"
+                    value={type.code}
+                    onChange={e => updateType(i, 'code', e.target.value)}
+                  />
+                </div>
+                <div className="fs-schedule-setup-field">
+                  <label htmlFor={`type-desc-${i}`}>Description</label>
+                  <input
+                    id={`type-desc-${i}`}
+                    type="text"
+                    className="fs-schedule-setup-input"
+                    placeholder="Office Visit"
+                    value={type.description || ''}
+                    onChange={e => updateType(i, 'description', e.target.value)}
+                  />
+                </div>
+                <div className="fs-schedule-setup-field">
+                  <label htmlFor={`type-dur-${i}`}>Duration</label>
+                  <select
+                    id={`type-dur-${i}`}
+                    className="fs-schedule-setup-input"
+                    value={type.duration || 30}
+                    onChange={e => updateType(i, 'duration', Number(e.target.value))}
+                  >
+                    {DURATION_OPTIONS.map(d => (
+                      <option key={d} value={d}>{d} min</option>
+                    ))}
+                  </select>
+                </div>
+                <button
+                  type="button"
+                  className="fs-block-remove"
+                  onClick={() => removeType(i)}
+                  aria-label={`Remove type ${type.code || i + 1}`}
+                >
+                  ×
+                </button>
+              </div>
+            ))}
+            <button type="button" className="fs-secondary-button" onClick={addType}>
+              + Add Type
+            </button>
+          </div>
+        )}
+      </section>
+
+      {/* Preview */}
+      {preview && (
+        <section className="fs-schedule-setup-section fs-preview" aria-label="Slot preview" aria-live="polite">
+          <h3 className="fs-schedule-setup-label">Preview</h3>
+          <div className="fs-preview-summary">
+            <strong>{preview.totalSlots.toLocaleString()}</strong> slots across{' '}
+            <strong>{preview.dayCount}</strong> days
+            <span className="fs-preview-detail"> ({preview.perDay} slots/day)</span>
+          </div>
+          {preview.totalSlots > 5000 && (
+            <div className="fs-preview-warning" role="alert">
+              ⚠️ Large number of slots — consider a shorter date range for better performance.
+            </div>
+          )}
+          <div className="fs-preview-dates">
+            <span className="fs-preview-dates-label">Sample dates: </span>
+            {preview.sampleDates.map((d, i) => (
+              <span key={i} className="fs-preview-date">{d}</span>
+            ))}
+          </div>
+        </section>
+      )}
+
+      {/* YAML config (collapsible) */}
+      <section className="fs-schedule-setup-section" aria-label="YAML configuration">
+        <button
+          type="button"
+          className="fs-schedule-setup-toggle"
+          onClick={() => setShowYaml(!showYaml)}
+          aria-expanded={showYaml}
+        >
+          <span className={`fs-toggle-arrow ${showYaml ? 'fs-toggle-arrow-open' : ''}`}>▸</span>
+          YAML Config
+          <span className="fs-schedule-setup-optional">(import / export)</span>
+        </button>
+        {showYaml && (
+          <div className="fs-yaml-section">
+            <p className="fs-yaml-hint">
+              Edit the YAML below and click <strong>Apply</strong> to update the form,
+              or use the form above and the YAML updates automatically.
+            </p>
+            <textarea
+              className="fs-yaml-textarea"
+              value={yamlText}
+              onChange={e => { setYamlText(e.target.value); setYamlError(null); }}
+              spellCheck={false}
+              rows={16}
+              aria-label="Schedule YAML configuration"
+            />
+            {yamlError && (
+              <div className="fs-yaml-error" role="alert">{yamlError}</div>
+            )}
+            <div className="fs-yaml-actions">
+              <button
+                type="button"
+                className="fs-primary-button"
+                onClick={applyYaml}
+              >
+                Apply YAML → Form
+              </button>
+              <button
+                type="button"
+                className="fs-secondary-button"
+                onClick={() => {
+                  navigator.clipboard.writeText(yamlText);
+                }}
+              >
+                Copy to Clipboard
+              </button>
+            </div>
+          </div>
+        )}
+      </section>
+
+      {/* Generate actions */}
+      <section className="fs-schedule-setup-section fs-generate-actions" aria-label="Generate slots">
+        <div className="fs-generate-mode" role="radiogroup" aria-label="Generation mode">
+          <label className="fs-generate-mode-option">
+            <input
+              type="radio"
+              name="generate-mode"
+              value="replace"
+              checked={mode === 'replace'}
+              onChange={() => setMode('replace')}
+            />
+            Replace existing free slots
+          </label>
+          <label className="fs-generate-mode-option">
+            <input
+              type="radio"
+              name="generate-mode"
+              value="incremental"
+              checked={mode === 'incremental'}
+              onChange={() => setMode('incremental')}
+            />
+            Keep existing, add new
+          </label>
+        </div>
+
+        <button
+          type="button"
+          className="fs-primary-button fs-generate-btn"
+          onClick={handleGenerate}
+          disabled={!canGenerate}
+          aria-busy={generating}
+        >
+          {generating ? 'Generating…' : 'Generate Slots'}
+        </button>
+      </section>
+
+      {/* Result / Error messages */}
+      {result && (
+        <div className="fs-schedule-setup-result fs-schedule-setup-success" role="status" aria-live="polite">
+          ✅ Created <strong>{result.slotsCreated.toLocaleString()}</strong> slots
+          {result.slotsDeleted > 0 && (
+            <span> (replaced {result.slotsDeleted.toLocaleString()} existing free slots)</span>
+          )}
+          {result.warnings && (
+            <div className="fs-schedule-setup-warnings">⚠️ {result.warnings}</div>
+          )}
+        </div>
+      )}
+      {error && (
+        <div className="fs-error-banner" role="alert" aria-live="assertive">
+          {error}
+        </div>
+      )}
+    </div>
+  );
+}

--- a/packages/fhir-scheduler/src/index.ts
+++ b/packages/fhir-scheduler/src/index.ts
@@ -6,6 +6,7 @@ export { BookingForm, ConnectedBookingForm } from './components/BookingForm';
 export { Confirmation, ConnectedConfirmation } from './components/Confirmation';
 export { AppointmentList } from './components/AppointmentList';
 export { ImportData } from './components/ImportData';
+export { ScheduleSetup } from './components/ScheduleSetup';
 
 // Store exports
 export { useSchedulerStore } from './store/schedulerStore';
@@ -24,4 +25,8 @@ export type {
   SlotHold,
   SchedulerWidgetProps,
   SchedulerStep,
+  AvailabilityTemplate,
+  AvailabilityBlock,
+  AppointmentTypeDefinition,
+  GenerateSlotsResult,
 } from './types';

--- a/packages/fhir-scheduler/src/provider-view.tsx
+++ b/packages/fhir-scheduler/src/provider-view.tsx
@@ -2,6 +2,7 @@ import React, { useState, useCallback } from 'react';
 import { createRoot } from 'react-dom/client';
 import { AppointmentList } from './components/AppointmentList';
 import { ImportData } from './components/ImportData';
+import { ScheduleSetup } from './components/ScheduleSetup';
 import './styles/scheduler.css';
 
 // Determine FHIR API base URL
@@ -14,7 +15,7 @@ const urlParams = new URLSearchParams(window.location.search);
 const initialScheduleId = urlParams.get('schedule') || undefined;
 const initialDate = urlParams.get('date') || undefined;
 
-type TabType = 'appointments' | 'import';
+type TabType = 'appointments' | 'schedule-setup' | 'import';
 
 function ProviderView() {
   const [activeTab, setActiveTab] = useState<TabType>('appointments');
@@ -43,6 +44,16 @@ function ProviderView() {
         <button
           type="button"
           role="tab"
+          aria-selected={activeTab === 'schedule-setup'}
+          aria-controls="tab-schedule-setup"
+          className={`fs-demo-tab ${activeTab === 'schedule-setup' ? 'fs-demo-tab-active' : ''}`}
+          onClick={() => setActiveTab('schedule-setup')}
+        >
+          Schedule Setup
+        </button>
+        <button
+          type="button"
+          role="tab"
           aria-selected={activeTab === 'import'}
           aria-controls="tab-import"
           className={`fs-demo-tab ${activeTab === 'import' ? 'fs-demo-tab-active' : ''}`}
@@ -61,6 +72,23 @@ function ProviderView() {
       >
         {activeTab === 'appointments' && (
           <AppointmentList key={refreshKey} fhirBaseUrl={fhirBaseUrl} initialScheduleId={initialScheduleId} initialDate={initialDate} />
+        )}
+      </div>
+
+      <div
+        id="tab-schedule-setup"
+        role="tabpanel"
+        aria-labelledby="tab-schedule-setup"
+        hidden={activeTab !== 'schedule-setup'}
+      >
+        {activeTab === 'schedule-setup' && (
+          <ScheduleSetup
+            fhirBaseUrl={fhirBaseUrl}
+            initialScheduleId={initialScheduleId}
+            onGenerate={() => {
+              setRefreshKey((k) => k + 1);
+            }}
+          />
         )}
       </div>
 

--- a/packages/fhir-scheduler/src/styles/scheduler.css
+++ b/packages/fhir-scheduler/src/styles/scheduler.css
@@ -1790,3 +1790,562 @@
   background-color: #f9fafb;
   border-color: #9ca3af;
 }
+
+/* ==================== Schedule Setup ==================== */
+
+.fs-schedule-setup {
+  max-width: 720px;
+}
+
+.fs-schedule-setup-header {
+  margin-bottom: 1.25rem;
+}
+
+.fs-schedule-setup-subtitle {
+  margin: 0.25rem 0 0;
+  font-size: 0.875rem;
+  color: #6b7280;
+}
+
+.fs-schedule-setup-section {
+  margin-bottom: 1.25rem;
+}
+
+.fs-schedule-setup-label {
+  display: block;
+  font-weight: 600;
+  font-size: 0.875rem;
+  color: #374151;
+  margin-bottom: 0.375rem;
+}
+
+.fs-schedule-setup-label-row {
+  display: flex;
+  align-items: center;
+  gap: 0.75rem;
+  margin-bottom: 0.375rem;
+}
+
+.fs-schedule-setup-preset-btn {
+  font-size: 0.75rem;
+  padding: 0.125rem 0.5rem;
+}
+
+.fs-schedule-setup-row {
+  display: flex;
+  gap: 1rem;
+  flex-wrap: wrap;
+}
+
+.fs-schedule-setup-field {
+  display: flex;
+  flex-direction: column;
+  gap: 0.25rem;
+}
+
+.fs-schedule-setup-field label {
+  font-size: 0.75rem;
+  color: #6b7280;
+}
+
+.fs-schedule-setup-input {
+  padding: 0.375rem 0.5rem;
+  font-size: 0.875rem;
+  border: 1px solid #d1d5db;
+  border-radius: 0.375rem;
+  color: #1f2937;
+  background: #fff;
+}
+
+.fs-schedule-setup-input:focus {
+  outline: 2px solid #2563eb;
+  outline-offset: -1px;
+  border-color: #2563eb;
+}
+
+/* Weekday picker */
+
+.fs-weekday-picker {
+  display: flex;
+  gap: 0.375rem;
+  flex-wrap: wrap;
+}
+
+.fs-weekday-btn {
+  width: 2.75rem;
+  height: 2.25rem;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  font-size: 0.8125rem;
+  font-weight: 500;
+  border: 1px solid #d1d5db;
+  border-radius: 0.375rem;
+  background: #fff;
+  color: #374151;
+  cursor: pointer;
+  transition: all 0.15s ease;
+}
+
+.fs-weekday-btn:hover {
+  border-color: #2563eb;
+  color: #2563eb;
+}
+
+.fs-weekday-btn-active {
+  background: #2563eb;
+  border-color: #2563eb;
+  color: #fff;
+}
+
+.fs-weekday-btn-active:hover {
+  background: #1d4ed8;
+  border-color: #1d4ed8;
+  color: #fff;
+}
+
+/* Block list */
+
+.fs-block-list {
+  display: flex;
+  flex-direction: column;
+  gap: 0.5rem;
+  margin-bottom: 0.5rem;
+}
+
+.fs-block-row {
+  display: flex;
+  align-items: flex-end;
+  gap: 0.75rem;
+  flex-wrap: wrap;
+  padding: 0.625rem;
+  background: #f9fafb;
+  border: 1px solid #e5e7eb;
+  border-radius: 0.5rem;
+}
+
+.fs-block-remove {
+  width: 1.75rem;
+  height: 1.75rem;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  background: none;
+  border: 1px solid #d1d5db;
+  border-radius: 0.25rem;
+  color: #9ca3af;
+  cursor: pointer;
+  font-size: 1rem;
+  line-height: 1;
+  flex-shrink: 0;
+}
+
+.fs-block-remove:hover:not(:disabled) {
+  background: #fee2e2;
+  border-color: #fca5a5;
+  color: #dc2626;
+}
+
+.fs-block-remove:disabled {
+  opacity: 0.3;
+  cursor: not-allowed;
+}
+
+/* Per-block type checkboxes */
+
+.fs-block-types {
+  flex-basis: 100%;
+  display: flex;
+  align-items: center;
+  gap: 0.75rem;
+  flex-wrap: wrap;
+  padding-top: 0.25rem;
+}
+
+.fs-block-types-label {
+  font-size: 0.75rem;
+  color: #6b7280;
+  font-weight: 500;
+}
+
+.fs-block-type-check {
+  display: flex;
+  align-items: center;
+  gap: 0.25rem;
+  font-size: 0.8125rem;
+  color: #374151;
+  cursor: pointer;
+}
+
+/* Appointment type list */
+
+.fs-type-list {
+  padding-left: 1rem;
+  margin-top: 0.5rem;
+}
+
+.fs-type-row {
+  display: flex;
+  align-items: flex-end;
+  gap: 0.75rem;
+  flex-wrap: wrap;
+  padding: 0.5rem;
+  margin-bottom: 0.5rem;
+  background: #f9fafb;
+  border: 1px solid #e5e7eb;
+  border-radius: 0.5rem;
+}
+
+/* Collapsible toggle */
+
+.fs-schedule-setup-toggle {
+  display: flex;
+  align-items: center;
+  gap: 0.375rem;
+  background: none;
+  border: none;
+  font-size: 0.875rem;
+  font-weight: 600;
+  color: #374151;
+  cursor: pointer;
+  padding: 0;
+}
+
+.fs-schedule-setup-toggle:hover {
+  color: #2563eb;
+}
+
+.fs-schedule-setup-optional {
+  font-weight: 400;
+  font-size: 0.75rem;
+  color: #9ca3af;
+}
+
+.fs-toggle-arrow {
+  display: inline-block;
+  transition: transform 0.15s ease;
+  font-size: 0.875rem;
+}
+
+.fs-toggle-arrow-open {
+  transform: rotate(90deg);
+}
+
+/* Preview */
+
+.fs-preview {
+  padding: 0.75rem 1rem;
+  background: #eff6ff;
+  border: 1px solid #bfdbfe;
+  border-radius: 0.5rem;
+}
+
+.fs-preview-summary {
+  font-size: 0.9375rem;
+  color: #1e40af;
+}
+
+.fs-preview-detail {
+  font-size: 0.8125rem;
+  color: #3b82f6;
+}
+
+.fs-preview-warning {
+  margin-top: 0.375rem;
+  font-size: 0.8125rem;
+  color: #92400e;
+  background: #fef3c7;
+  padding: 0.25rem 0.5rem;
+  border-radius: 0.25rem;
+}
+
+.fs-preview-dates {
+  margin-top: 0.5rem;
+  font-size: 0.8125rem;
+  color: #6b7280;
+}
+
+.fs-preview-dates-label {
+  font-weight: 500;
+}
+
+.fs-preview-date {
+  display: inline-block;
+  margin-right: 0.375rem;
+  font-family: monospace;
+  font-size: 0.75rem;
+  background: #dbeafe;
+  padding: 0.0625rem 0.375rem;
+  border-radius: 0.25rem;
+}
+
+/* Generate actions */
+
+.fs-generate-actions {
+  padding-top: 0.75rem;
+  border-top: 1px solid #e5e7eb;
+}
+
+.fs-generate-mode {
+  display: flex;
+  gap: 1.25rem;
+  margin-bottom: 0.75rem;
+}
+
+.fs-generate-mode-option {
+  display: flex;
+  align-items: center;
+  gap: 0.375rem;
+  font-size: 0.8125rem;
+  color: #374151;
+  cursor: pointer;
+}
+
+.fs-generate-btn {
+  min-width: 10rem;
+}
+
+/* Result messages */
+
+.fs-schedule-setup-result {
+  margin-top: 0.75rem;
+  padding: 0.75rem 1rem;
+  border-radius: 0.5rem;
+  font-size: 0.875rem;
+}
+
+.fs-schedule-setup-success {
+  background: #ecfdf5;
+  border: 1px solid #a7f3d0;
+  color: #065f46;
+}
+
+.fs-schedule-setup-warnings {
+  margin-top: 0.375rem;
+  color: #92400e;
+}
+
+/* Recurrence tabs (Outlook-style Daily / Weekly / Monthly / Yearly) */
+
+.fs-recurrence-tabs {
+  display: flex;
+  gap: 0;
+  border: 1px solid #d1d5db;
+  border-radius: 0.375rem;
+  overflow: hidden;
+  margin-bottom: 0.75rem;
+}
+
+.fs-recurrence-tab {
+  flex: 1;
+  padding: 0.375rem 0.75rem;
+  font-size: 0.8125rem;
+  font-weight: 500;
+  color: #374151;
+  background: #fff;
+  border: none;
+  cursor: pointer;
+  transition: background 0.15s, color 0.15s;
+  text-align: center;
+}
+
+.fs-recurrence-tab + .fs-recurrence-tab {
+  border-left: 1px solid #d1d5db;
+}
+
+.fs-recurrence-tab:hover {
+  background: #f3f4f6;
+}
+
+.fs-recurrence-tab-active {
+  background: #2563eb;
+  color: #fff;
+  font-weight: 600;
+}
+
+.fs-recurrence-tab-active:hover {
+  background: #1d4ed8;
+}
+
+/* Recurrence panel (content below tabs) */
+
+.fs-recurrence-panel {
+  display: flex;
+  flex-direction: column;
+  gap: 0.625rem;
+  padding: 0.75rem;
+  background: #f9fafb;
+  border: 1px solid #e5e7eb;
+  border-radius: 0.375rem;
+  margin-bottom: 0.75rem;
+}
+
+/* Radio row: "Every [input] day(s)" or "The [select] [select] of every [input] month(s)" */
+
+.fs-recurrence-radio-row {
+  display: flex;
+  align-items: center;
+  gap: 0.375rem;
+  font-size: 0.8125rem;
+  color: #374151;
+  cursor: pointer;
+  flex-wrap: wrap;
+}
+
+.fs-recurrence-radio-row input[type="radio"] {
+  margin: 0;
+  flex-shrink: 0;
+}
+
+/* Inline row (no radio): "Recur every [input] week(s) on:" */
+
+.fs-recurrence-inline-row {
+  display: flex;
+  align-items: center;
+  gap: 0.375rem;
+  font-size: 0.8125rem;
+  color: #374151;
+  margin-bottom: 0.25rem;
+}
+
+/* Small number input inside recurrence rows */
+
+.fs-recurrence-num {
+  width: 3.25rem;
+  padding: 0.25rem 0.375rem;
+  font-size: 0.8125rem;
+  border: 1px solid #d1d5db;
+  border-radius: 0.25rem;
+  text-align: center;
+}
+
+.fs-recurrence-num:focus {
+  outline: none;
+  border-color: #2563eb;
+  box-shadow: 0 0 0 2px rgba(37, 99, 235, 0.15);
+}
+
+.fs-recurrence-num:disabled {
+  background: #f3f4f6;
+  color: #9ca3af;
+}
+
+/* Compact select inside recurrence rows */
+
+.fs-recurrence-select {
+  padding: 0.25rem 0.375rem;
+  font-size: 0.8125rem;
+  border: 1px solid #d1d5db;
+  border-radius: 0.25rem;
+  background: #fff;
+}
+
+.fs-recurrence-select:focus {
+  outline: none;
+  border-color: #2563eb;
+  box-shadow: 0 0 0 2px rgba(37, 99, 235, 0.15);
+}
+
+.fs-recurrence-select:disabled {
+  background: #f3f4f6;
+  color: #9ca3af;
+}
+
+/* Generated RRULE display (small code badge) */
+
+.fs-rrule-display {
+  margin-bottom: 0.5rem;
+  padding: 0.25rem 0.5rem;
+  background: #f3f4f6;
+  border: 1px solid #e5e7eb;
+  border-radius: 0.25rem;
+  display: inline-block;
+}
+
+.fs-rrule-display code {
+  font-family: 'SF Mono', 'Fira Code', 'Consolas', monospace;
+  font-size: 0.75rem;
+  color: #4b5563;
+}
+
+.fs-schedule-setup-sublabel {
+  font-size: 0.8125rem;
+  font-weight: 500;
+  color: #4b5563;
+}
+
+/* Excluded dates */
+
+.fs-exdates-section {
+  margin-top: 0.75rem;
+  padding-top: 0.5rem;
+  border-top: 1px solid #f3f4f6;
+}
+
+.fs-exdate-list {
+  display: flex;
+  flex-direction: column;
+  gap: 0.375rem;
+  margin-top: 0.375rem;
+}
+
+.fs-exdate-row {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+}
+
+.fs-exdate-row .fs-schedule-setup-input {
+  width: auto;
+}
+
+/* YAML config section */
+
+.fs-yaml-section {
+  margin-top: 0.5rem;
+}
+
+.fs-yaml-hint {
+  font-size: 0.8125rem;
+  color: #6b7280;
+  margin: 0 0 0.5rem 0;
+}
+
+.fs-yaml-textarea {
+  width: 100%;
+  min-height: 14rem;
+  padding: 0.75rem;
+  font-family: 'SF Mono', 'Fira Code', 'Consolas', monospace;
+  font-size: 0.8125rem;
+  line-height: 1.5;
+  border: 1px solid #d1d5db;
+  border-radius: 0.375rem;
+  background: #f9fafb;
+  color: #1f2937;
+  resize: vertical;
+  box-sizing: border-box;
+  tab-size: 2;
+}
+
+.fs-yaml-textarea:focus {
+  outline: none;
+  border-color: #2563eb;
+  box-shadow: 0 0 0 2px rgba(37, 99, 235, 0.15);
+  background: #fff;
+}
+
+.fs-yaml-error {
+  margin-top: 0.375rem;
+  font-size: 0.8125rem;
+  color: #dc2626;
+  background: #fef2f2;
+  padding: 0.375rem 0.5rem;
+  border-radius: 0.25rem;
+  border: 1px solid #fecaca;
+}
+
+.fs-yaml-actions {
+  display: flex;
+  gap: 0.5rem;
+  margin-top: 0.5rem;
+}

--- a/packages/fhir-scheduler/src/types/index.ts
+++ b/packages/fhir-scheduler/src/types/index.ts
@@ -221,3 +221,49 @@ export type VisitType = 'new-patient' | 'follow-up';
  * Scheduler workflow steps
  */
 export type SchedulerStep = 'visit-type' | 'questionnaire' | 'providers' | 'calendar' | 'booking' | 'confirmation';
+
+// ==================== Schedule Setup / Availability Template ====================
+
+/**
+ * Availability block — a daily time window that generates slots
+ */
+export interface AvailabilityBlock {
+  start: string;            // "08:00" (24h)
+  end: string;              // "12:00" (24h)
+  duration: number;         // minutes per slot
+  types?: string[];         // allowed appointment type codes
+  overbook?: number;        // max concurrent overbookings (0 = none)
+}
+
+/**
+ * Named appointment type definition
+ */
+export interface AppointmentTypeDefinition {
+  code: string;
+  description?: string;
+  duration?: number;
+}
+
+/**
+ * Availability template — defines recurring schedule availability.
+ * Submitted to POST /Schedule/:id/$generate-slots to create Slot resources.
+ */
+export interface AvailabilityTemplate {
+  startDate: string;        // "2026-05-01"
+  endDate: string;          // "2026-10-28"
+  weekdays: string[];       // ["mon", "tue", "wed", "thu", "fri"]
+  rrule?: string;           // RFC 5545 RRULE (overrides weekdays when present)
+  exdates?: string[];       // dates to exclude (holidays)
+  appointmentTypes?: AppointmentTypeDefinition[];
+  blocks: AvailabilityBlock[];
+}
+
+/**
+ * Result from the $generate-slots operation
+ */
+export interface GenerateSlotsResult {
+  slotsCreated: number;
+  slotsDeleted: number;
+  mode: string;
+  warnings?: string;
+}

--- a/public/hl7-tester.html
+++ b/public/hl7-tester.html
@@ -828,7 +828,9 @@ function renderCards() {
       <div class="slot-builder" id="slots-${ex.id}">
         <h3>📅 Generate Slots for <span class="slot-provider-name"></span></h3>
         <p class="slot-builder-desc">
-          Define availability as YAML. Slots are created as <code>free</code> for the schedule returned above.
+          Define availability as <a href="https://github.com/mieweb/FHIRTogether/blob/main/docs/scheduling-models.md#step-2-define-availability-with-the-schedule-yaml-format" target="_blank">Schedule YAML</a>.
+          Supports time blocks, appointment types, and overbooking.
+          Slots are created as <code>free</code> for the schedule returned above.
         </p>
         <textarea class="slot-yaml" id="slot-yaml-${ex.id}" spellcheck="false"
                   aria-label="YAML slot definition for ${ex.title}"></textarea>
@@ -1034,10 +1036,20 @@ function showDeepLinks(id, scheduleRef, actorDisplay, apiKey, appointmentDate) {
       `endDate:   "${endDate}"`,
       `weekdays:  [mon, tue, wed, thu, fri]`,
       ``,
+      `# appointmentTypes:`,
+      `#   - code: OV`,
+      `#     description: "Office Visit"`,
+      `#     duration: 30`,
+      `#   - code: FU`,
+      `#     description: "Follow-Up"`,
+      `#     duration: 15`,
+      ``,
       `blocks:`,
       `  - start: "09:00"`,
       `    end:   "12:00"`,
       `    duration: 30    # minutes per slot`,
+      `    # overbook: 0   # max concurrent (0 = no overbooking)`,
+      `    # types: [OV, FU]  # allowed appointment types`,
       `  - start: "13:00"`,
       `    end:   "17:00"`,
       `    duration: 30`,
@@ -1065,59 +1077,72 @@ function toggleSlotBuilder(id) {
 
 /**
  * Minimal YAML-ish parser for the slot definition format.
- * Supports: key: "value", key: [a, b, c], nested blocks with - start/end/duration.
+ * Supports: key: "value", key: [a, b, c], nested blocks with - start/end/duration,
+ * appointmentTypes list, and per-block overbook/types fields.
  */
 function parseSlotYAML(text) {
   const lines = text.split('\n').filter(l => l.trim() && !l.trim().startsWith('#'));
-  const result = { blocks: [] };
-  let inBlocks = false;
-  let currentBlock = null;
+  const result = { blocks: [], appointmentTypes: [] };
+  let section = null; // 'blocks' | 'appointmentTypes'
+  let currentItem = null;
+
+  function flushItem() {
+    if (!currentItem) return;
+    if (section === 'blocks') result.blocks.push(currentItem);
+    else if (section === 'appointmentTypes') result.appointmentTypes.push(currentItem);
+    currentItem = null;
+  }
+
+  function parseValue(raw) {
+    const val = raw.trim();
+    if (val.startsWith('[') && val.endsWith(']')) {
+      return val.slice(1, -1).split(',').map(s => s.trim().replace(/^"|"$/g, ''));
+    }
+    return val.replace(/^"(.*)"$/, '$1');
+  }
 
   for (const line of lines) {
     const trimmed = line.trim();
 
-    if (trimmed === 'blocks:') { inBlocks = true; continue; }
+    if (trimmed === 'blocks:') { flushItem(); section = 'blocks'; continue; }
+    if (trimmed === 'appointmentTypes:') { flushItem(); section = 'appointmentTypes'; continue; }
 
-    if (inBlocks) {
+    if (section) {
       if (trimmed.startsWith('- ')) {
-        if (currentBlock) result.blocks.push(currentBlock);
-        currentBlock = {};
+        flushItem();
+        currentItem = {};
         const kv = trimmed.slice(2).trim();
-        const m = kv.match(/^(\w+):\s*"?([^"#]+)"?\s*/);
-        if (m) currentBlock[m[1]] = m[2].trim();
-      } else if (trimmed.match(/^\w+:/) && currentBlock) {
-        const m = trimmed.match(/^(\w+):\s*"?([^"#]+)"?\s*/);
-        if (m) currentBlock[m[1]] = m[2].trim();
+        const m = kv.match(/^(\w+):\s*(.+?)\s*(?:#.*)?$/);
+        if (m) currentItem[m[1]] = parseValue(m[2]);
+      } else if (trimmed.match(/^\w+:/) && currentItem) {
+        const m = trimmed.match(/^(\w+):\s*(.+?)\s*(?:#.*)?$/);
+        if (m) currentItem[m[1]] = parseValue(m[2]);
       } else if (!trimmed.startsWith(' ') && !trimmed.startsWith('-')) {
-        // End of blocks section
-        if (currentBlock) { result.blocks.push(currentBlock); currentBlock = null; }
-        inBlocks = false;
+        flushItem();
+        section = null;
       }
     }
 
-    if (!inBlocks) {
-      // Top-level key-value
+    if (!section) {
       const kvMatch = trimmed.match(/^(\w+):\s*(.+)/);
       if (kvMatch) {
         const key = kvMatch[1];
-        let val = kvMatch[2].trim();
-        // Array syntax: [mon, tue, ...]
-        if (val.startsWith('[') && val.endsWith(']')) {
-          val = val.slice(1, -1).split(',').map(s => s.trim().toLowerCase());
-        } else {
-          val = val.replace(/^"(.*)"$/, '$1');
-        }
-        result[key] = val;
+        result[key] = parseValue(kvMatch[2]);
       }
     }
   }
-  if (currentBlock) result.blocks.push(currentBlock);
+  flushItem();
+  // Normalize weekdays to lowercase
+  if (Array.isArray(result.weekdays)) {
+    result.weekdays = result.weekdays.map(d => d.toLowerCase());
+  }
   return result;
 }
 
 /**
  * Expand a parsed slot YAML definition into individual Slot resource bodies.
- * Returns an array of { schedule, status, start, end } objects.
+ * Returns an array of Slot objects with optional appointmentType, overbooked,
+ * and serviceType fields based on the YAML appointmentTypes and block config.
  */
 function expandSlots(parsed, scheduleRef) {
   const dayMap = { sun: 0, mon: 1, tue: 2, wed: 3, thu: 4, fri: 5, sat: 6 };
@@ -1126,27 +1151,57 @@ function expandSlots(parsed, scheduleRef) {
   const endDate = new Date(parsed.endDate + 'T00:00:00');
   const slots = [];
 
+  // Build a lookup for appointment types by code
+  const typeMap = {};
+  for (const t of (parsed.appointmentTypes || [])) {
+    typeMap[t.code] = t;
+  }
+
   for (let d = new Date(startDate); d <= endDate; d.setDate(d.getDate() + 1)) {
     if (!weekdays.includes(d.getDay())) continue;
     const dateStr = d.toISOString().slice(0, 10);
 
     for (const block of parsed.blocks) {
       const duration = parseInt(block.duration, 10) || 30;
+      const overbook = parseInt(block.overbook, 10);
       const [startH, startM] = block.start.split(':').map(Number);
       const [endH, endM] = block.end.split(':').map(Number);
       const blockStartMin = startH * 60 + startM;
       const blockEndMin = endH * 60 + endM;
 
+      // Determine allowed appointment types for this block
+      const blockTypes = Array.isArray(block.types) ? block.types : null;
+
       for (let min = blockStartMin; min + duration <= blockEndMin; min += duration) {
         const slotStart = `${dateStr}T${String(Math.floor(min/60)).padStart(2,'0')}:${String(min%60).padStart(2,'0')}:00`;
         const slotEnd = `${dateStr}T${String(Math.floor((min+duration)/60)).padStart(2,'0')}:${String((min+duration)%60).padStart(2,'0')}:00`;
-        slots.push({
+        const slot = {
           resourceType: 'Slot',
           schedule: { reference: scheduleRef },
           status: 'free',
           start: slotStart,
           end: slotEnd,
-        });
+        };
+
+        // Add appointmentType from first allowed type if defined
+        if (blockTypes && blockTypes.length > 0) {
+          const primary = typeMap[blockTypes[0]];
+          if (primary) {
+            slot.appointmentType = { text: primary.description || primary.code };
+          }
+          // Store all allowed types as serviceType
+          slot.serviceType = blockTypes
+            .map(code => typeMap[code] ? { text: typeMap[code].description || code } : { text: code })
+            .filter(Boolean);
+        }
+
+        // Add overbooking if configured
+        if (overbook > 0) {
+          slot.overbooked = false; // Slot is not yet overbooked, but allows it
+          slot.comment = `overbook:${overbook}`;
+        }
+
+        slots.push(slot);
       }
     }
   }
@@ -1175,6 +1230,7 @@ async function createSlots(id) {
     headers['Authorization'] = `Bearer ${apiKey}`;
   }
 
+  // Quick client-side pre-validation for immediate feedback
   let parsed;
   try {
     parsed = parseSlotYAML(yamlText);
@@ -1188,56 +1244,70 @@ async function createSlots(id) {
     return;
   }
 
-  const slots = expandSlots(parsed, scheduleRef);
-  if (slots.length === 0) {
-    status.textContent = 'No slots generated — check date range and weekdays';
-    return;
-  }
-
   btn.disabled = true;
-  status.textContent = `Creating ${slots.length} slots…`;
+  status.textContent = 'Generating slots on server…';
   resultEl.classList.remove('visible');
 
-  let created = 0;
-  let failed = 0;
-  const errors = [];
+  // Extract schedule ID from reference (e.g. "Schedule/abc-123" → "abc-123")
+  const scheduleId = scheduleRef.replace(/^Schedule\//, '');
 
-  for (const slot of slots) {
-    try {
-      const res = await fetch('/Slot', {
-        method: 'POST',
-        headers,
-        body: JSON.stringify(slot),
-      });
-      if (res.ok) {
-        created++;
-      } else {
-        failed++;
-        const body = await res.text();
-        if (errors.length < 3) errors.push(`${res.status}: ${body}`);
-      }
-    } catch (e) {
-      failed++;
-      if (errors.length < 3) errors.push(e.message);
+  try {
+    const res = await fetch(`/Schedule/${encodeURIComponent(scheduleId)}/$generate-slots`, {
+      method: 'POST',
+      headers,
+      body: JSON.stringify({ yaml: yamlText }),
+    });
+
+    const body = await res.json();
+
+    btn.disabled = false;
+
+    if (!res.ok) {
+      const errorMsg = body.error || 'Server error';
+      const details = body.details ? body.details.join('; ') : '';
+      status.textContent = `❌ ${errorMsg}`;
+      resultEl.textContent = details || JSON.stringify(body, null, 2);
+      resultEl.className = 'slot-result visible response-error';
+      return;
     }
-    // Update progress every 10 slots
-    if ((created + failed) % 10 === 0) {
-      status.textContent = `Creating slots… ${created + failed}/${slots.length}`;
+
+    // Parse result from OperationOutcome extensions
+    const resultExt = (body.extension || []).find(e => e.url?.includes('generate-slots-result'));
+    const extMap = {};
+    for (const e of (resultExt?.extension || [])) {
+      extMap[e.url] = e.valueInteger ?? e.valueString ?? e.value;
     }
+
+    const created = extMap.slotsCreated || 0;
+    const deleted = extMap.slotsDeleted || 0;
+    const warnings = extMap.warnings || '';
+
+    status.textContent = `✅ Created ${created} slots` +
+      (deleted > 0 ? ` (replaced ${deleted} old free slots)` : '') +
+      (warnings ? ` ⚠️ ${warnings}` : '');
+
+    let detail = `${created} free slots for ${scheduleRef}\n`;
+    detail += `Date range: ${parsed.startDate} → ${parsed.endDate}\n`;
+    detail += `Blocks: ${parsed.blocks.map(b => {
+      let desc = `${b.start}–${b.end} (${b.duration}min)`;
+      if (Array.isArray(b.types)) desc += ` [${b.types.join(', ')}]`;
+      if (parseInt(b.overbook, 10) > 0) desc += ` overbook:${b.overbook}`;
+      return desc;
+    }).join(', ')}`;
+    if (parsed.appointmentTypes.length) {
+      detail += `\nTypes: ${parsed.appointmentTypes.map(t => `${t.code} (${t.description})`).join(', ')}`;
+    }
+    if (warnings) detail += `\n\nWarnings: ${warnings}`;
+    detail += `\n\nTemplate saved on schedule for future regeneration.`;
+
+    resultEl.textContent = detail;
+    resultEl.className = 'slot-result visible response-success';
+  } catch (e) {
+    btn.disabled = false;
+    status.textContent = `❌ Network error: ${e.message}`;
+    resultEl.textContent = e.stack || e.message;
+    resultEl.className = 'slot-result visible response-error';
   }
-
-  btn.disabled = false;
-
-  const summary = `✅ Created ${created} slots` + (failed ? ` · ❌ ${failed} failed` : '');
-  status.textContent = summary;
-
-  let detail = `${created} free slots for ${scheduleRef}\n`;
-  detail += `Date range: ${parsed.startDate} → ${parsed.endDate}\n`;
-  detail += `Blocks: ${parsed.blocks.map(b => `${b.start}–${b.end} (${b.duration}min)`).join(', ')}`;
-  if (errors.length) detail += `\n\nErrors:\n${errors.join('\n')}`;
-
-  resultEl.textContent = detail;
-  resultEl.className = 'slot-result visible ' + (failed ? 'response-error' : 'response-success');
 }
 
 async function sendAll() {

--- a/src/__tests__/slotExpander.test.ts
+++ b/src/__tests__/slotExpander.test.ts
@@ -1,0 +1,304 @@
+import {
+  parseSlotYAML,
+  validateTemplate,
+  expandSlots,
+  AvailabilityTemplate,
+} from '../scheduling/slotExpander';
+
+// ==================== parseSlotYAML ====================
+
+describe('parseSlotYAML', () => {
+  it('parses a minimal YAML template', () => {
+    const yaml = `
+startDate: "2026-05-01"
+endDate:   "2026-05-02"
+weekdays:  [mon, tue, wed, thu, fri]
+
+blocks:
+  - start: "09:00"
+    end:   "12:00"
+    duration: 30
+`;
+    const result = parseSlotYAML(yaml);
+    expect(result.startDate).toBe('2026-05-01');
+    expect(result.endDate).toBe('2026-05-02');
+    expect(result.weekdays).toEqual(['mon', 'tue', 'wed', 'thu', 'fri']);
+    expect(result.blocks).toHaveLength(1);
+    expect(result.blocks[0].start).toBe('09:00');
+    expect(result.blocks[0].end).toBe('12:00');
+    expect(result.blocks[0].duration).toBe('30'); // parsed as string from YAML
+  });
+
+  it('parses appointmentTypes and block types/overbook', () => {
+    const yaml = `
+startDate: "2026-06-01"
+endDate:   "2026-06-30"
+weekdays:  [mon, wed, fri]
+
+appointmentTypes:
+  - code: OV
+    description: "Office Visit"
+    duration: 30
+  - code: FU
+    description: "Follow-Up"
+    duration: 15
+
+blocks:
+  - start: "08:00"
+    end:   "12:00"
+    duration: 30
+    types: [OV, FU]
+    overbook: 2
+`;
+    const result = parseSlotYAML(yaml);
+    expect(result.appointmentTypes).toHaveLength(2);
+    expect(result.appointmentTypes![0].code).toBe('OV');
+    expect(result.appointmentTypes![1].description).toBe('Follow-Up');
+    expect(result.blocks[0].types).toEqual(['OV', 'FU']);
+    expect(result.blocks[0].overbook).toBe('2');
+  });
+
+  it('strips comments from YAML', () => {
+    const yaml = `
+# This is a comment
+startDate: "2026-05-01"  # inline comment gets stripped by regex
+endDate: "2026-05-01"
+weekdays: [mon]
+blocks:
+  - start: "09:00"
+    end: "10:00"
+    duration: 30
+`;
+    const result = parseSlotYAML(yaml);
+    expect(result.startDate).toBe('2026-05-01');
+  });
+
+  it('normalizes weekdays to lowercase', () => {
+    const yaml = `
+startDate: "2026-05-01"
+endDate: "2026-05-01"
+weekdays: [Mon, TUE, Wed]
+blocks:
+  - start: "09:00"
+    end: "10:00"
+    duration: 30
+`;
+    const result = parseSlotYAML(yaml);
+    expect(result.weekdays).toEqual(['mon', 'tue', 'wed']);
+  });
+});
+
+// ==================== validateTemplate ====================
+
+describe('validateTemplate', () => {
+  const validTemplate: AvailabilityTemplate = {
+    startDate: '2026-05-01',
+    endDate: '2026-05-31',
+    weekdays: ['mon', 'tue', 'wed', 'thu', 'fri'],
+    blocks: [{ start: '09:00', end: '12:00', duration: 30 }],
+  };
+
+  it('returns no errors for a valid template', () => {
+    expect(validateTemplate(validTemplate)).toEqual([]);
+  });
+
+  it('rejects missing startDate', () => {
+    const errors = validateTemplate({ ...validTemplate, startDate: '' });
+    expect(errors).toContainEqual(expect.stringContaining('startDate'));
+  });
+
+  it('rejects startDate after endDate', () => {
+    const errors = validateTemplate({ ...validTemplate, startDate: '2026-06-01', endDate: '2026-05-01' });
+    expect(errors).toContainEqual(expect.stringContaining('startDate must be before'));
+  });
+
+  it('rejects invalid weekday names', () => {
+    const errors = validateTemplate({ ...validTemplate, weekdays: ['monday'] });
+    expect(errors).toContainEqual(expect.stringContaining('Invalid weekday'));
+  });
+
+  it('rejects empty blocks array', () => {
+    const errors = validateTemplate({ ...validTemplate, blocks: [] });
+    expect(errors).toContainEqual(expect.stringContaining('blocks'));
+  });
+
+  it('rejects block with start >= end', () => {
+    const errors = validateTemplate({
+      ...validTemplate,
+      blocks: [{ start: '12:00', end: '09:00', duration: 30 }],
+    });
+    expect(errors).toContainEqual(expect.stringContaining('start must be before'));
+  });
+
+  it('rejects invalid duration', () => {
+    const errors = validateTemplate({
+      ...validTemplate,
+      blocks: [{ start: '09:00', end: '12:00', duration: 0 }],
+    });
+    expect(errors).toContainEqual(expect.stringContaining('duration'));
+  });
+
+  it('rejects block type referencing undefined appointment type', () => {
+    const errors = validateTemplate({
+      ...validTemplate,
+      appointmentTypes: [{ code: 'OV', description: 'Office Visit' }],
+      blocks: [{ start: '09:00', end: '12:00', duration: 30, types: ['OV', 'UNKNOWN'] }],
+    });
+    expect(errors).toContainEqual(expect.stringContaining('undefined appointment type "UNKNOWN"'));
+  });
+
+  it('accepts blocks with types matching defined appointmentTypes', () => {
+    const errors = validateTemplate({
+      ...validTemplate,
+      appointmentTypes: [{ code: 'OV' }, { code: 'FU' }],
+      blocks: [{ start: '09:00', end: '12:00', duration: 30, types: ['OV', 'FU'] }],
+    });
+    expect(errors).toEqual([]);
+  });
+});
+
+// ==================== expandSlots ====================
+
+describe('expandSlots', () => {
+  it('generates correct number of slots for a single day and block', () => {
+    const template: AvailabilityTemplate = {
+      startDate: '2026-05-04', // Monday
+      endDate: '2026-05-04',
+      weekdays: ['mon'],
+      blocks: [{ start: '09:00', end: '12:00', duration: 30 }],
+    };
+    const { slots, warnings } = expandSlots(template, 'Schedule/test-1');
+    // 09:00-12:00 with 30min = 6 slots
+    expect(slots).toHaveLength(6);
+    expect(warnings).toEqual([]);
+  });
+
+  it('generates correct start/end times', () => {
+    const template: AvailabilityTemplate = {
+      startDate: '2026-05-04',
+      endDate: '2026-05-04',
+      weekdays: ['mon'],
+      blocks: [{ start: '09:00', end: '10:00', duration: 20 }],
+    };
+    const { slots } = expandSlots(template, 'Schedule/test-1');
+    // 09:00-10:00 with 20min = 3 slots (09:00, 09:20, 09:40)
+    expect(slots).toHaveLength(3);
+    expect(slots[0].start).toBe('2026-05-04T09:00:00');
+    expect(slots[0].end).toBe('2026-05-04T09:20:00');
+    expect(slots[1].start).toBe('2026-05-04T09:20:00');
+    expect(slots[2].start).toBe('2026-05-04T09:40:00');
+    expect(slots[2].end).toBe('2026-05-04T10:00:00');
+  });
+
+  it('skips days not in weekdays', () => {
+    const template: AvailabilityTemplate = {
+      startDate: '2026-05-04', // Monday
+      endDate: '2026-05-10',   // Sunday
+      weekdays: ['mon', 'wed', 'fri'],
+      blocks: [{ start: '09:00', end: '10:00', duration: 60 }],
+    };
+    const { slots } = expandSlots(template, 'Schedule/test-1');
+    // Only Mon, Wed, Fri = 3 days × 1 slot each = 3
+    expect(slots).toHaveLength(3);
+  });
+
+  it('handles multiple blocks (lunch break)', () => {
+    const template: AvailabilityTemplate = {
+      startDate: '2026-05-04',
+      endDate: '2026-05-04',
+      weekdays: ['mon'],
+      blocks: [
+        { start: '09:00', end: '12:00', duration: 60 }, // 3 slots
+        { start: '13:00', end: '15:00', duration: 60 }, // 2 slots
+      ],
+    };
+    const { slots } = expandSlots(template, 'Schedule/test-1');
+    expect(slots).toHaveLength(5);
+  });
+
+  it('sets schedule reference on all slots', () => {
+    const template: AvailabilityTemplate = {
+      startDate: '2026-05-04',
+      endDate: '2026-05-04',
+      weekdays: ['mon'],
+      blocks: [{ start: '09:00', end: '10:00', duration: 30 }],
+    };
+    const { slots } = expandSlots(template, 'Schedule/my-sched');
+    for (const slot of slots) {
+      expect(slot.schedule.reference).toBe('Schedule/my-sched');
+      expect(slot.status).toBe('free');
+      expect(slot.resourceType).toBe('Slot');
+    }
+  });
+
+  it('adds appointmentType and serviceType from block types', () => {
+    const template: AvailabilityTemplate = {
+      startDate: '2026-05-04',
+      endDate: '2026-05-04',
+      weekdays: ['mon'],
+      appointmentTypes: [
+        { code: 'OV', description: 'Office Visit', duration: 30 },
+        { code: 'FU', description: 'Follow-Up', duration: 15 },
+      ],
+      blocks: [{ start: '09:00', end: '09:30', duration: 30, types: ['OV', 'FU'] }],
+    };
+    const { slots } = expandSlots(template, 'Schedule/test-1');
+    expect(slots).toHaveLength(1);
+    expect(slots[0].appointmentType).toEqual({ text: 'Office Visit' });
+    expect(slots[0].serviceType).toEqual([
+      { text: 'Office Visit' },
+      { text: 'Follow-Up' },
+    ]);
+  });
+
+  it('adds overbook comment when configured', () => {
+    const template: AvailabilityTemplate = {
+      startDate: '2026-05-04',
+      endDate: '2026-05-04',
+      weekdays: ['mon'],
+      blocks: [{ start: '09:00', end: '09:30', duration: 30, overbook: 3 }],
+    };
+    const { slots } = expandSlots(template, 'Schedule/test-1');
+    expect(slots[0].overbooked).toBe(false);
+    expect(slots[0].comment).toBe('overbook:3');
+  });
+
+  it('does not set overbook fields when overbook is 0 or undefined', () => {
+    const template: AvailabilityTemplate = {
+      startDate: '2026-05-04',
+      endDate: '2026-05-04',
+      weekdays: ['mon'],
+      blocks: [{ start: '09:00', end: '09:30', duration: 30, overbook: 0 }],
+    };
+    const { slots } = expandSlots(template, 'Schedule/test-1');
+    expect(slots[0].overbooked).toBeUndefined();
+    expect(slots[0].comment).toBeUndefined();
+  });
+
+  it('returns empty array when date range has no matching weekdays', () => {
+    const template: AvailabilityTemplate = {
+      startDate: '2026-05-04', // Monday
+      endDate: '2026-05-04',
+      weekdays: ['sat', 'sun'],
+      blocks: [{ start: '09:00', end: '12:00', duration: 30 }],
+    };
+    const { slots } = expandSlots(template, 'Schedule/test-1');
+    expect(slots).toHaveLength(0);
+  });
+
+  it('warns when generating many slots', () => {
+    const template: AvailabilityTemplate = {
+      startDate: '2026-01-01',
+      endDate: '2026-12-31', // full year
+      weekdays: ['mon', 'tue', 'wed', 'thu', 'fri'],
+      blocks: [
+        { start: '08:00', end: '12:00', duration: 15 }, // 16 slots/block
+        { start: '13:00', end: '17:00', duration: 15 }, // 16 slots/block
+      ],
+    };
+    const { slots, warnings } = expandSlots(template, 'Schedule/test-1');
+    // ~261 weekdays × 32 slots = ~8352
+    expect(slots.length).toBeGreaterThan(5000);
+    expect(warnings.some(w => w.includes('consider a shorter date range'))).toBe(true);
+  });
+});

--- a/src/__tests__/slotExpander.test.ts
+++ b/src/__tests__/slotExpander.test.ts
@@ -302,3 +302,150 @@ describe('expandSlots', () => {
     expect(warnings.some(w => w.includes('consider a shorter date range'))).toBe(true);
   });
 });
+
+// ==================== RRULE support ====================
+
+describe('parseSlotYAML (RRULE fields)', () => {
+  it('parses rrule field', () => {
+    const yaml = `
+startDate: "2026-05-01"
+endDate: "2026-05-31"
+rrule: "FREQ=WEEKLY;BYDAY=MO,WE,FR"
+
+blocks:
+  - start: "09:00"
+    end: "12:00"
+    duration: 30
+`;
+    const result = parseSlotYAML(yaml);
+    expect(result.rrule).toBe('FREQ=WEEKLY;BYDAY=MO,WE,FR');
+  });
+
+  it('parses exdates array', () => {
+    const yaml = `
+startDate: "2026-05-01"
+endDate: "2026-05-31"
+weekdays: [mon, tue, wed, thu, fri]
+exdates: [2026-05-05, 2026-05-26]
+
+blocks:
+  - start: "09:00"
+    end: "12:00"
+    duration: 30
+`;
+    const result = parseSlotYAML(yaml);
+    expect(result.exdates).toEqual(['2026-05-05', '2026-05-26']);
+  });
+});
+
+describe('validateTemplate (RRULE)', () => {
+  const baseTemplate: AvailabilityTemplate = {
+    startDate: '2026-05-01',
+    endDate: '2026-05-31',
+    weekdays: [],
+    rrule: 'FREQ=WEEKLY;BYDAY=MO,WE,FR',
+    blocks: [{ start: '09:00', end: '12:00', duration: 30 }],
+  };
+
+  it('accepts valid rrule without weekdays', () => {
+    expect(validateTemplate(baseTemplate)).toEqual([]);
+  });
+
+  it('rejects invalid rrule syntax', () => {
+    const errors = validateTemplate({ ...baseTemplate, rrule: 'INVALID_RRULE' });
+    expect(errors).toContainEqual(expect.stringContaining('Invalid rrule'));
+  });
+
+  it('rejects invalid exdates format', () => {
+    const errors = validateTemplate({ ...baseTemplate, exdates: ['not-a-date'] });
+    expect(errors).toContainEqual(expect.stringContaining('exdates[0]'));
+  });
+
+  it('accepts valid exdates', () => {
+    const errors = validateTemplate({ ...baseTemplate, exdates: ['2026-07-04', '2026-12-25'] });
+    expect(errors).toEqual([]);
+  });
+});
+
+describe('expandSlots (RRULE)', () => {
+  it('generates slots using RRULE BYDAY', () => {
+    const template: AvailabilityTemplate = {
+      startDate: '2026-05-04', // Monday
+      endDate: '2026-05-10',   // Sunday
+      weekdays: [],
+      rrule: 'FREQ=WEEKLY;BYDAY=MO,WE,FR',
+      blocks: [{ start: '09:00', end: '10:00', duration: 60 }],
+    };
+    const { slots } = expandSlots(template, 'Schedule/test-1');
+    // Mon, Wed, Fri = 3 days × 1 slot = 3
+    expect(slots).toHaveLength(3);
+  });
+
+  it('supports bi-weekly RRULE (INTERVAL=2)', () => {
+    const template: AvailabilityTemplate = {
+      startDate: '2026-05-04', // Monday week 1
+      endDate: '2026-05-31',   // 4 weeks
+      weekdays: [],
+      rrule: 'FREQ=WEEKLY;INTERVAL=2;BYDAY=MO',
+      blocks: [{ start: '09:00', end: '10:00', duration: 60 }],
+    };
+    const { slots } = expandSlots(template, 'Schedule/test-1');
+    // Bi-weekly Mondays starting May 4: May 4, May 18 = 2
+    expect(slots).toHaveLength(2);
+  });
+
+  it('supports monthly RRULE (first Monday)', () => {
+    const template: AvailabilityTemplate = {
+      startDate: '2026-05-01',
+      endDate: '2026-08-31', // 4 months
+      weekdays: [],
+      rrule: 'FREQ=MONTHLY;BYDAY=1MO',
+      blocks: [{ start: '09:00', end: '10:00', duration: 60 }],
+    };
+    const { slots } = expandSlots(template, 'Schedule/test-1');
+    // First Monday: May 4, Jun 1, Jul 6, Aug 3 = 4
+    expect(slots).toHaveLength(4);
+  });
+
+  it('excludes dates listed in exdates', () => {
+    const template: AvailabilityTemplate = {
+      startDate: '2026-05-04',
+      endDate: '2026-05-08',
+      weekdays: ['mon', 'tue', 'wed', 'thu', 'fri'],
+      exdates: ['2026-05-06'], // skip Wednesday
+      blocks: [{ start: '09:00', end: '10:00', duration: 60 }],
+    };
+    const { slots } = expandSlots(template, 'Schedule/test-1');
+    // Mon–Fri minus Wed = 4 days × 1 slot = 4
+    expect(slots).toHaveLength(4);
+    const dates = slots.map(s => s.start?.slice(0, 10));
+    expect(dates).not.toContain('2026-05-06');
+  });
+
+  it('exdates works with RRULE too', () => {
+    const template: AvailabilityTemplate = {
+      startDate: '2026-05-04',
+      endDate: '2026-05-10',
+      weekdays: [],
+      rrule: 'FREQ=WEEKLY;BYDAY=MO,WE,FR',
+      exdates: ['2026-05-08'], // skip Friday
+      blocks: [{ start: '09:00', end: '10:00', duration: 60 }],
+    };
+    const { slots } = expandSlots(template, 'Schedule/test-1');
+    // Mon, Wed, (Fri excluded) = 2
+    expect(slots).toHaveLength(2);
+  });
+
+  it('RRULE overrides weekdays when both present', () => {
+    const template: AvailabilityTemplate = {
+      startDate: '2026-05-04',
+      endDate: '2026-05-10',
+      weekdays: ['mon', 'tue', 'wed', 'thu', 'fri'], // ignored when rrule present
+      rrule: 'FREQ=WEEKLY;BYDAY=TU,TH',
+      blocks: [{ start: '09:00', end: '10:00', duration: 60 }],
+    };
+    const { slots } = expandSlots(template, 'Schedule/test-1');
+    // RRULE says Tue, Thu only = 2
+    expect(slots).toHaveLength(2);
+  });
+});

--- a/src/routes/scheduleRoutes.ts
+++ b/src/routes/scheduleRoutes.ts
@@ -1,5 +1,6 @@
 import { FastifyInstance, FastifyRequest, FastifyReply } from 'fastify';
 import { FhirStore, Schedule, FhirScheduleQuery, Bundle } from '../types/fhir';
+import { parseSlotYAML, validateTemplate, expandSlots, AvailabilityTemplate } from '../scheduling';
 
 interface ScheduleParams {
   id: string;
@@ -230,6 +231,118 @@ export async function scheduleRoutes(fastify: FastifyInstance, store: FhirStore)
       
       await store.deleteAllSchedules();
       return reply.code(204).send();
+    }
+  );
+
+  // POST /Schedule/:id/$generate-slots — Generate slots from availability template
+  fastify.post<{ Params: ScheduleParams; Body: { yaml?: string; template?: AvailabilityTemplate }; Querystring: { mode?: string } }>(
+    '/Schedule/:id/\\$generate-slots',
+    {
+      schema: {
+        description: 'Generate Slot resources from a YAML availability template or JSON template. ' +
+          'Mode "replace" (default) deletes existing free slots first; "incremental" keeps them.',
+        tags: ['Schedule'],
+        params: {
+          type: 'object', additionalProperties: true,
+          required: ['id'],
+          properties: {
+            id: { type: 'string' },
+          },
+        },
+        querystring: {
+          type: 'object', additionalProperties: true,
+          properties: {
+            mode: { type: 'string', enum: ['replace', 'incremental'], description: 'replace (default) or incremental' },
+          },
+        },
+        body: {
+          type: 'object', additionalProperties: true,
+          properties: {
+            yaml: { type: 'string', description: 'YAML availability template text' },
+            template: { type: 'object', additionalProperties: true, description: 'JSON availability template' },
+          },
+        },
+        response: {
+          200: {
+            type: 'object', additionalProperties: true,
+            description: 'Result with slot count and warnings',
+          },
+          400: {
+            type: 'object', additionalProperties: true,
+            properties: { error: { type: 'string' }, details: { type: 'array' } },
+          },
+          404: {
+            type: 'object', additionalProperties: true,
+            properties: { error: { type: 'string' } },
+          },
+        },
+      },
+    },
+    async (request, reply) => {
+      // Verify schedule exists
+      const schedule = await store.getScheduleById(request.params.id);
+      if (!schedule) {
+        return reply.code(404).send({ error: 'Schedule not found' });
+      }
+
+      // Parse template from YAML text or JSON body
+      let template: AvailabilityTemplate;
+      const body = request.body || {};
+
+      if (body.yaml) {
+        try {
+          template = parseSlotYAML(body.yaml);
+        } catch (err) {
+          return reply.code(400).send({ error: 'Invalid YAML', details: [(err as Error).message] });
+        }
+      } else if (body.template) {
+        template = body.template;
+      } else {
+        return reply.code(400).send({ error: 'Request must include "yaml" (string) or "template" (object)' });
+      }
+
+      // Validate
+      const errors = validateTemplate(template);
+      if (errors.length > 0) {
+        return reply.code(400).send({ error: 'Invalid availability template', details: errors });
+      }
+
+      // Expand into Slot resources
+      const scheduleRef = `Schedule/${request.params.id}`;
+      const { slots, warnings } = expandSlots(template, scheduleRef);
+
+      // Replace mode: delete existing free slots in this schedule first
+      const mode = request.query.mode || 'replace';
+      let deletedCount = 0;
+      if (mode === 'replace') {
+        deletedCount = await store.deleteSlotsBySchedule(request.params.id, 'free');
+      }
+
+      // Bulk insert
+      const { count } = await store.createSlots(slots);
+
+      // Store the template on the schedule for future reference
+      const templateJson = JSON.stringify(template);
+      await store.setAvailabilityTemplate(request.params.id, templateJson);
+
+      return reply.send({
+        resourceType: 'OperationOutcome',
+        issue: [{
+          severity: 'information',
+          code: 'informational',
+          diagnostics: `Generated ${count} slots for ${scheduleRef}` +
+            (deletedCount > 0 ? ` (replaced ${deletedCount} existing free slots)` : ''),
+        }],
+        extension: [{
+          url: 'https://fhirtogether.org/StructureDefinition/generate-slots-result',
+          extension: [
+            { url: 'slotsCreated', valueInteger: count },
+            { url: 'slotsDeleted', valueInteger: deletedCount },
+            { url: 'mode', valueString: mode },
+            ...(warnings.length > 0 ? [{ url: 'warnings', valueString: warnings.join('; ') }] : []),
+          ],
+        }],
+      });
     }
   );
 }

--- a/src/scheduling/index.ts
+++ b/src/scheduling/index.ts
@@ -1,0 +1,15 @@
+/**
+ * Scheduling Module — availability template parsing and slot expansion.
+ */
+export {
+  parseSlotYAML,
+  validateTemplate,
+  expandSlots,
+} from './slotExpander';
+
+export type {
+  AvailabilityTemplate,
+  AvailabilityBlock,
+  AppointmentTypeDefinition,
+  ExpandResult,
+} from './slotExpander';

--- a/src/scheduling/slotExpander.ts
+++ b/src/scheduling/slotExpander.ts
@@ -11,6 +11,7 @@
  * Schedule resources. See docs/scheduling-models.md for the full specification.
  */
 
+import { RRule } from 'rrule';
 import { Slot, CodeableConcept } from '../types/fhir';
 
 // ==================== TYPES ====================
@@ -33,6 +34,8 @@ export interface AvailabilityTemplate {
   startDate: string;        // "2026-05-01"
   endDate: string;          // "2026-10-28"
   weekdays: string[];       // ["mon", "tue", "wed", "thu", "fri"]
+  rrule?: string;           // RFC 5545 RRULE (overrides weekdays when present)
+  exdates?: string[];       // ["2026-07-04"] — dates to exclude (holidays)
   appointmentTypes?: AppointmentTypeDefinition[];
   blocks: AvailabilityBlock[];
 }
@@ -107,6 +110,13 @@ export function parseSlotYAML(text: string): AvailabilityTemplate {
     result.weekdays = (result.weekdays as string[]).map(d => d.toLowerCase());
   }
 
+  // Normalize exdates from string to array
+  if (typeof result.exdates === 'string') {
+    result.exdates = [result.exdates];
+  } else if (Array.isArray(result.exdates)) {
+    result.exdates = (result.exdates as string[]).map(d => d.trim());
+  }
+
   return result as unknown as AvailabilityTemplate;
 }
 
@@ -129,12 +139,28 @@ export function validateTemplate(template: AvailabilityTemplate): string[] {
     errors.push('startDate must be before or equal to endDate');
   }
 
-  if (!Array.isArray(template.weekdays) || template.weekdays.length === 0) {
-    errors.push('weekdays is required and must be a non-empty array');
+  // Validate RRULE if present; otherwise require weekdays
+  if (template.rrule) {
+    try {
+      RRule.fromString(template.rrule);
+    } catch (e) {
+      errors.push(`Invalid rrule: ${(e as Error).message}`);
+    }
+  } else if (!Array.isArray(template.weekdays) || template.weekdays.length === 0) {
+    errors.push('weekdays is required (or provide an rrule) and must be a non-empty array');
   } else {
     for (const day of template.weekdays) {
       if (!VALID_WEEKDAYS.has(day.toLowerCase())) {
         errors.push(`Invalid weekday: "${day}". Must be one of: ${[...VALID_WEEKDAYS].join(', ')}`);
+      }
+    }
+  }
+
+  // Validate exdates format
+  if (template.exdates) {
+    for (let i = 0; i < template.exdates.length; i++) {
+      if (!DATE_RE.test(template.exdates[i])) {
+        errors.push(`exdates[${i}] must be YYYY-MM-DD, got "${template.exdates[i]}"`);
       }
     }
   }
@@ -207,11 +233,12 @@ export function expandSlots(
   scheduleRef: string,
 ): ExpandResult {
   const warnings: string[] = [];
-  const weekdayNums = (template.weekdays || ['mon', 'tue', 'wed', 'thu', 'fri'])
-    .map(d => DAY_MAP[d.toLowerCase()]);
   const startDate = new Date(template.startDate + 'T00:00:00');
   const endDate = new Date(template.endDate + 'T00:00:00');
   const slots: Omit<Slot, 'id' | 'meta'>[] = [];
+
+  // Build set of excluded dates
+  const exdateSet = new Set((template.exdates || []).map(d => d.trim()));
 
   // Build lookup for appointment types by code
   const typeMap = new Map<string, AppointmentTypeDefinition>();
@@ -219,9 +246,14 @@ export function expandSlots(
     typeMap.set(t.code, t);
   }
 
-  for (let d = new Date(startDate); d <= endDate; d.setDate(d.getDate() + 1)) {
-    if (!weekdayNums.includes(d.getDay())) continue;
-    const dateStr = d.toISOString().slice(0, 10);
+  // Resolve dates: RRULE-driven or weekday-driven
+  const dates = template.rrule
+    ? expandDatesFromRRule(template.rrule, startDate, endDate)
+    : expandDatesFromWeekdays(template.weekdays || ['mon', 'tue', 'wed', 'thu', 'fri'], startDate, endDate);
+
+  for (const d of dates) {
+    const dateStr = toDateString(d);
+    if (exdateSet.has(dateStr)) continue;
 
     for (const block of template.blocks) {
       const duration = parseInt(String(block.duration), 10) || 30;
@@ -281,6 +313,43 @@ export function expandSlots(
   }
 
   return { slots, warnings };
+}
+
+// ==================== DATE EXPANSION HELPERS ====================
+
+/**
+ * Expand dates from an RFC 5545 RRULE string, clamped to [start, end].
+ * The RRULE's own DTSTART/UNTIL are overridden by the template's startDate/endDate.
+ */
+function expandDatesFromRRule(rruleStr: string, start: Date, end: Date): Date[] {
+  // Parse the RRULE, then override DTSTART and UNTIL to match template bounds
+  const rule = RRule.fromString(rruleStr);
+  const bounded = new RRule({
+    ...rule.origOptions,
+    dtstart: start,
+    until: end,
+    count: undefined, // Remove count if UNTIL is set — template endDate wins
+  });
+  return bounded.all();
+}
+
+/**
+ * Expand dates from a weekday list (legacy mode), clamped to [start, end].
+ */
+function expandDatesFromWeekdays(weekdays: string[], start: Date, end: Date): Date[] {
+  const weekdayNums = weekdays.map(d => DAY_MAP[d.toLowerCase()]);
+  const dates: Date[] = [];
+  for (let d = new Date(start); d <= end; d.setDate(d.getDate() + 1)) {
+    if (weekdayNums.includes(d.getDay())) {
+      dates.push(new Date(d));
+    }
+  }
+  return dates;
+}
+
+/** Format a Date as YYYY-MM-DD without timezone shift. */
+function toDateString(d: Date): string {
+  return `${d.getFullYear()}-${pad2(d.getMonth() + 1)}-${pad2(d.getDate())}`;
 }
 
 function pad2(n: number): string {

--- a/src/scheduling/slotExpander.ts
+++ b/src/scheduling/slotExpander.ts
@@ -1,0 +1,288 @@
+/**
+ * Server-side Slot Expansion Engine
+ *
+ * Parses YAML availability templates and expands them into FHIR Slot resources.
+ * This is the single source of truth for schedule→slot expansion, used by:
+ *   - POST /Schedule/:id/$generate-slots  (server API)
+ *   - generateBusyOffice.ts               (test data generator)
+ *
+ * The YAML format is FHIRTogether's proprietary availability-template extension,
+ * filling a gap in FHIR R4/R5 where no standard exists for recurrence rules on
+ * Schedule resources. See docs/scheduling-models.md for the full specification.
+ */
+
+import { Slot, CodeableConcept } from '../types/fhir';
+
+// ==================== TYPES ====================
+
+export interface AppointmentTypeDefinition {
+  code: string;
+  description?: string;
+  duration?: number;
+}
+
+export interface AvailabilityBlock {
+  start: string;            // "08:00" (24h)
+  end: string;              // "12:00" (24h)
+  duration: number;         // minutes per slot
+  types?: string[];         // allowed appointment type codes
+  overbook?: number;        // max concurrent overbookings (0 = none)
+}
+
+export interface AvailabilityTemplate {
+  startDate: string;        // "2026-05-01"
+  endDate: string;          // "2026-10-28"
+  weekdays: string[];       // ["mon", "tue", "wed", "thu", "fri"]
+  appointmentTypes?: AppointmentTypeDefinition[];
+  blocks: AvailabilityBlock[];
+}
+
+export interface ExpandResult {
+  slots: Omit<Slot, 'id' | 'meta'>[];
+  warnings: string[];
+}
+
+// ==================== YAML PARSER ====================
+
+/**
+ * Minimal YAML-ish parser for the slot definition format.
+ * Supports: key: "value", key: [a, b, c], nested blocks with - start/end/duration,
+ * appointmentTypes list, and per-block overbook/types fields.
+ */
+export function parseSlotYAML(text: string): AvailabilityTemplate {
+  const lines = text.split('\n').filter(l => l.trim() && !l.trim().startsWith('#'));
+  const result: Record<string, unknown> = { blocks: [], appointmentTypes: [] };
+  let section: 'blocks' | 'appointmentTypes' | null = null;
+  let currentItem: Record<string, unknown> | null = null;
+
+  function flushItem(): void {
+    if (!currentItem) return;
+    if (section === 'blocks') (result.blocks as Record<string, unknown>[]).push(currentItem);
+    else if (section === 'appointmentTypes') (result.appointmentTypes as Record<string, unknown>[]).push(currentItem);
+    currentItem = null;
+  }
+
+  function parseValue(raw: string): string | string[] {
+    // Strip inline comments (# not inside quotes)
+    const val = raw.replace(/\s+#.*$/, '').trim();
+    if (val.startsWith('[') && val.endsWith(']')) {
+      return val.slice(1, -1).split(',').map(s => s.trim().replace(/^"|"$/g, ''));
+    }
+    return val.replace(/^"(.*)"$/, '$1');
+  }
+
+  for (const line of lines) {
+    const trimmed = line.trim();
+
+    if (trimmed === 'blocks:') { flushItem(); section = 'blocks'; continue; }
+    if (trimmed === 'appointmentTypes:') { flushItem(); section = 'appointmentTypes'; continue; }
+
+    if (section) {
+      if (trimmed.startsWith('- ')) {
+        flushItem();
+        currentItem = {};
+        const kv = trimmed.slice(2).trim();
+        const m = kv.match(/^(\w+):\s*(.+?)\s*(?:#.*)?$/);
+        if (m) currentItem[m[1]] = parseValue(m[2]);
+      } else if (trimmed.match(/^\w+:/) && currentItem) {
+        const m = trimmed.match(/^(\w+):\s*(.+?)\s*(?:#.*)?$/);
+        if (m) currentItem[m[1]] = parseValue(m[2]);
+      } else if (!trimmed.startsWith(' ') && !trimmed.startsWith('-')) {
+        flushItem();
+        section = null;
+      }
+    }
+
+    if (!section) {
+      const kvMatch = trimmed.match(/^(\w+):\s*(.+)/);
+      if (kvMatch) {
+        result[kvMatch[1]] = parseValue(kvMatch[2]);
+      }
+    }
+  }
+  flushItem();
+
+  // Normalize weekdays to lowercase
+  if (Array.isArray(result.weekdays)) {
+    result.weekdays = (result.weekdays as string[]).map(d => d.toLowerCase());
+  }
+
+  return result as unknown as AvailabilityTemplate;
+}
+
+// ==================== VALIDATION ====================
+
+const VALID_WEEKDAYS = new Set(['sun', 'mon', 'tue', 'wed', 'thu', 'fri', 'sat']);
+const TIME_RE = /^\d{2}:\d{2}$/;
+const DATE_RE = /^\d{4}-\d{2}-\d{2}$/;
+
+export function validateTemplate(template: AvailabilityTemplate): string[] {
+  const errors: string[] = [];
+
+  if (!template.startDate || !DATE_RE.test(template.startDate)) {
+    errors.push('startDate is required and must be YYYY-MM-DD');
+  }
+  if (!template.endDate || !DATE_RE.test(template.endDate)) {
+    errors.push('endDate is required and must be YYYY-MM-DD');
+  }
+  if (template.startDate && template.endDate && template.startDate > template.endDate) {
+    errors.push('startDate must be before or equal to endDate');
+  }
+
+  if (!Array.isArray(template.weekdays) || template.weekdays.length === 0) {
+    errors.push('weekdays is required and must be a non-empty array');
+  } else {
+    for (const day of template.weekdays) {
+      if (!VALID_WEEKDAYS.has(day.toLowerCase())) {
+        errors.push(`Invalid weekday: "${day}". Must be one of: ${[...VALID_WEEKDAYS].join(', ')}`);
+      }
+    }
+  }
+
+  if (!Array.isArray(template.blocks) || template.blocks.length === 0) {
+    errors.push('blocks is required and must be a non-empty array');
+  } else {
+    for (let i = 0; i < template.blocks.length; i++) {
+      const block = template.blocks[i];
+      const prefix = `blocks[${i}]`;
+
+      if (!block.start || !TIME_RE.test(block.start)) {
+        errors.push(`${prefix}.start is required and must be HH:MM`);
+      }
+      if (!block.end || !TIME_RE.test(block.end)) {
+        errors.push(`${prefix}.end is required and must be HH:MM`);
+      }
+      if (block.start && block.end && block.start >= block.end) {
+        errors.push(`${prefix}.start must be before ${prefix}.end`);
+      }
+
+      const duration = parseInt(String(block.duration), 10);
+      if (!duration || duration < 1 || duration > 480) {
+        errors.push(`${prefix}.duration must be 1–480 minutes`);
+      }
+
+      if (block.overbook !== undefined) {
+        const ob = parseInt(String(block.overbook), 10);
+        if (isNaN(ob) || ob < 0) {
+          errors.push(`${prefix}.overbook must be a non-negative integer`);
+        }
+      }
+    }
+  }
+
+  // Validate appointment type codes referenced by blocks exist in definitions
+  if (template.appointmentTypes && template.appointmentTypes.length > 0) {
+    const definedCodes = new Set(template.appointmentTypes.map(t => t.code));
+    for (let i = 0; i < (template.blocks || []).length; i++) {
+      const block = template.blocks[i];
+      if (block.types) {
+        for (const code of block.types) {
+          if (!definedCodes.has(code)) {
+            errors.push(`blocks[${i}].types references undefined appointment type "${code}"`);
+          }
+        }
+      }
+    }
+  }
+
+  return errors;
+}
+
+// ==================== SLOT EXPANSION ====================
+
+const DAY_MAP: Record<string, number> = {
+  sun: 0, mon: 1, tue: 2, wed: 3, thu: 4, fri: 5, sat: 6,
+};
+
+const MAX_SLOTS = 50000;
+
+/**
+ * Expand an availability template into individual FHIR Slot resource bodies.
+ *
+ * Returns slots with optional appointmentType, overbooked, and serviceType
+ * fields based on the template's appointmentTypes and block config.
+ */
+export function expandSlots(
+  template: AvailabilityTemplate,
+  scheduleRef: string,
+): ExpandResult {
+  const warnings: string[] = [];
+  const weekdayNums = (template.weekdays || ['mon', 'tue', 'wed', 'thu', 'fri'])
+    .map(d => DAY_MAP[d.toLowerCase()]);
+  const startDate = new Date(template.startDate + 'T00:00:00');
+  const endDate = new Date(template.endDate + 'T00:00:00');
+  const slots: Omit<Slot, 'id' | 'meta'>[] = [];
+
+  // Build lookup for appointment types by code
+  const typeMap = new Map<string, AppointmentTypeDefinition>();
+  for (const t of (template.appointmentTypes || [])) {
+    typeMap.set(t.code, t);
+  }
+
+  for (let d = new Date(startDate); d <= endDate; d.setDate(d.getDate() + 1)) {
+    if (!weekdayNums.includes(d.getDay())) continue;
+    const dateStr = d.toISOString().slice(0, 10);
+
+    for (const block of template.blocks) {
+      const duration = parseInt(String(block.duration), 10) || 30;
+      const overbook = parseInt(String(block.overbook), 10);
+      const [startH, startM] = block.start.split(':').map(Number);
+      const [endH, endM] = block.end.split(':').map(Number);
+      const blockStartMin = startH * 60 + startM;
+      const blockEndMin = endH * 60 + endM;
+
+      // Determine allowed appointment types for this block
+      const blockTypes = Array.isArray(block.types) ? block.types : null;
+
+      for (let min = blockStartMin; min + duration <= blockEndMin; min += duration) {
+        if (slots.length >= MAX_SLOTS) {
+          warnings.push(`Slot limit (${MAX_SLOTS}) reached — expansion stopped early`);
+          return { slots, warnings };
+        }
+
+        const slotStart = `${dateStr}T${pad2(Math.floor(min / 60))}:${pad2(min % 60)}:00`;
+        const slotEnd = `${dateStr}T${pad2(Math.floor((min + duration) / 60))}:${pad2((min + duration) % 60)}:00`;
+
+        const slot: Omit<Slot, 'id' | 'meta'> = {
+          resourceType: 'Slot',
+          schedule: { reference: scheduleRef },
+          status: 'free',
+          start: slotStart,
+          end: slotEnd,
+        };
+
+        // Add appointmentType from first allowed type if defined
+        if (blockTypes && blockTypes.length > 0) {
+          const primary = typeMap.get(blockTypes[0]);
+          if (primary) {
+            slot.appointmentType = { text: primary.description || primary.code };
+          }
+          // Store all allowed types as serviceType
+          slot.serviceType = blockTypes
+            .map(code => {
+              const t = typeMap.get(code);
+              return t ? { text: t.description || code } as CodeableConcept : { text: code } as CodeableConcept;
+            });
+        }
+
+        // Add overbooking if configured
+        if (overbook > 0) {
+          slot.overbooked = false; // Not yet overbooked, but allows it
+          slot.comment = `overbook:${overbook}`;
+        }
+
+        slots.push(slot);
+      }
+    }
+  }
+
+  if (slots.length >= 5000) {
+    warnings.push(`Generated ${slots.length} slots — consider a shorter date range for better performance`);
+  }
+
+  return { slots, warnings };
+}
+
+function pad2(n: number): string {
+  return String(n).padStart(2, '0');
+}

--- a/src/store/sqliteStore.ts
+++ b/src/store/sqliteStore.ts
@@ -51,7 +51,7 @@ function toNaiveISO(date: Date): string {
  * The store will compare it against the version stored in the database
  * and report a mismatch so the server can warn or rebuild.
  */
-export const SCHEMA_VERSION = 4;
+export const SCHEMA_VERSION = 5;
 
 export interface SchemaStatus {
   current: number;
@@ -259,6 +259,12 @@ export class SqliteStore implements FhirStore {
         this.db.prepare('UPDATE schedules SET system_id = ? WHERE system_id IS NULL').run(legacyId);
         console.log(`\n🔄 Migration v2→v3: Created "Legacy System" (${legacyId}) for ${existingCount} existing schedules\n`);
       }
+    }
+
+    // Migration v4→v5: add availability_template to schedules
+    const schedColsV5 = this.db.pragma('table_info(schedules)') as { name: string }[];
+    if (!schedColsV5.some(c => c.name === 'availability_template')) {
+      this.db.exec('ALTER TABLE schedules ADD COLUMN availability_template TEXT');
     }
 
     // Stamp the schema version after all migrations succeed
@@ -606,7 +612,7 @@ export class SqliteStore implements FhirStore {
 
   // ==================== SCHEDULE OPERATIONS ====================
 
-  async createSchedule(schedule: Schedule & { system_id?: string; location_id?: string }): Promise<Schedule> {
+  async createSchedule(schedule: Schedule & { system_id?: string; location_id?: string; availability_template?: string }): Promise<Schedule> {
     const id = schedule.id || this.generateId();
     const now = toNaiveISO(new Date());
 
@@ -614,8 +620,8 @@ export class SqliteStore implements FhirStore {
       INSERT INTO schedules (
         id, active, service_category, service_type, specialty, actor,
         planning_horizon_start, planning_horizon_end, comment, meta_last_updated,
-        system_id, location_id
-      ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+        system_id, location_id, availability_template
+      ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
     `);
 
     stmt.run(
@@ -631,6 +637,7 @@ export class SqliteStore implements FhirStore {
       now,
       schedule.system_id || null,
       schedule.location_id || null,
+      schedule.availability_template || null,
     );
 
     return { ...schedule, id, meta: { lastUpdated: now } };
@@ -711,6 +718,15 @@ export class SqliteStore implements FhirStore {
 
   async deleteAllSchedules(): Promise<void> {
     this.db.prepare('DELETE FROM schedules').run();
+  }
+
+  async setAvailabilityTemplate(scheduleId: string, template: string | null): Promise<void> {
+    this.db.prepare('UPDATE schedules SET availability_template = ? WHERE id = ?').run(template, scheduleId);
+  }
+
+  async getAvailabilityTemplate(scheduleId: string): Promise<string | null> {
+    const row = this.db.prepare('SELECT availability_template FROM schedules WHERE id = ?').get(scheduleId) as { availability_template: string | null } | undefined;
+    return row?.availability_template ?? null;
   }
 
   /**
@@ -863,6 +879,51 @@ export class SqliteStore implements FhirStore {
 
   async deleteAllSlots(): Promise<void> {
     this.db.prepare('DELETE FROM slots').run();
+  }
+
+  async createSlots(slots: Omit<Slot, 'id' | 'meta'>[]): Promise<{ count: number }> {
+    const now = toNaiveISO(new Date());
+    const stmt = this.db.prepare(`
+      INSERT INTO slots (
+        id, schedule_id, status, start, end, service_category, service_type,
+        specialty, appointment_type, overbooked, comment, meta_last_updated
+      ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+    `);
+
+    const insertAll = this.db.transaction((items: Omit<Slot, 'id' | 'meta'>[]) => {
+      for (const slot of items) {
+        const id = this.generateId();
+        const scheduleId = this.extractId(slot.schedule.reference);
+        stmt.run(
+          id,
+          scheduleId,
+          slot.status,
+          slot.start,
+          slot.end,
+          JSON.stringify(slot.serviceCategory || []),
+          JSON.stringify(slot.serviceType || []),
+          JSON.stringify(slot.specialty || []),
+          JSON.stringify(slot.appointmentType),
+          slot.overbooked ? 1 : 0,
+          slot.comment,
+          now,
+        );
+      }
+    });
+
+    insertAll(slots);
+    return { count: slots.length };
+  }
+
+  async deleteSlotsBySchedule(scheduleId: string, statusFilter?: string): Promise<number> {
+    let sql = 'DELETE FROM slots WHERE schedule_id = ?';
+    const params: SqlParam[] = [scheduleId];
+    if (statusFilter) {
+      sql += ' AND status = ?';
+      params.push(statusFilter);
+    }
+    const result = this.db.prepare(sql).run(...params);
+    return result.changes;
   }
 
   /**
@@ -1263,12 +1324,25 @@ export class SqliteStore implements FhirStore {
       meta: { lastUpdated: row.meta_last_updated },
     };
 
-    // Include system name as a FHIR extension when available
+    // Build FHIR extensions array
+    const extensions: { url: string; valueString?: string }[] = [];
+
     if (row.system_name) {
-      (schedule as Schedule & { extension?: unknown[] }).extension = [{
+      extensions.push({
         url: 'https://fhirtogether.org/fhir/StructureDefinition/system-name',
         valueString: row.system_name,
-      }];
+      });
+    }
+
+    if (row.availability_template) {
+      extensions.push({
+        url: 'https://fhirtogether.org/StructureDefinition/availability-template',
+        valueString: row.availability_template,
+      });
+    }
+
+    if (extensions.length > 0) {
+      (schedule as Schedule & { extension?: unknown[] }).extension = extensions;
     }
 
     return schedule;

--- a/src/types/fhir.ts
+++ b/src/types/fhir.ts
@@ -289,9 +289,11 @@ export interface FhirStore {
   getSlots(query: FhirSlotQuery): Promise<Slot[]>;
   getSlotById(id: string): Promise<Slot | null>;
   createSlot(slot: Slot): Promise<Slot>;
+  createSlots(slots: Omit<Slot, 'id' | 'meta'>[]): Promise<{ count: number }>;
   updateSlot(id: string, slot: Partial<Slot>): Promise<Slot>;
   deleteSlot(id: string): Promise<void>;
   deleteAllSlots(): Promise<void>;
+  deleteSlotsBySchedule(scheduleId: string, statusFilter?: string): Promise<number>;
 
   // Schedule operations
   getSchedules(query: FhirScheduleQuery): Promise<Schedule[]>;
@@ -300,6 +302,8 @@ export interface FhirStore {
   updateSchedule(id: string, schedule: Partial<Schedule>): Promise<Schedule>;
   deleteSchedule(id: string): Promise<void>;
   deleteAllSchedules(): Promise<void>;
+  setAvailabilityTemplate(scheduleId: string, template: string | null): Promise<void>;
+  getAvailabilityTemplate(scheduleId: string): Promise<string | null>;
 
   // Appointment operations
   getAppointments(query: FhirAppointmentQuery): Promise<Appointment[]>;


### PR DESCRIPTION
- Add src/scheduling/slotExpander.ts: YAML parser, template validator, slot expander
- Add POST /Schedule/:id/$generate-slots FHIR operation endpoint
- Add FhirStore batch methods: createSlots, deleteSlotsBySchedule
- Add availability_template column to schedules (schema v5)
- Update hl7-tester.html to call server endpoint instead of client-side expansion
- Add 23 unit tests for parseSlotYAML, validateTemplate, expandSlots
- Add docs/scheduling-models.md: comprehensive scheduling model documentation
- Add WebChartSchedulerAppointments.md: WebChart integration reference


<img width="595" height="834" alt="image" src="https://github.com/user-attachments/assets/73cc54a4-f168-46ec-bced-f4bb7be065cd" />

<img width="575" height="170" alt="image" src="https://github.com/user-attachments/assets/b9bd6e4a-004b-416b-9b5a-110b06ce6f21" />

<img width="588" height="181" alt="image" src="https://github.com/user-attachments/assets/88d3e017-b295-4c04-9391-65febd26bcf2" />

<img width="563" height="168" alt="image" src="https://github.com/user-attachments/assets/4546acbf-3325-499d-99c0-1c5db3af4a43" />
